### PR TITLE
Make MUD overlay follow site theme

### DIFF
--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -77,6 +77,25 @@
   const DARK_INK = { r: 15, g: 17, b: 21 };
   const LIGHT_INK = { r: 255, g: 255, b: 255 };
   const pickInk = (color) => (relativeLuminance(color) > 0.55 ? DARK_INK : LIGHT_INK);
+  const contrastRatio = (a, b) => {
+    const l1 = relativeLuminance(a);
+    const l2 = relativeLuminance(b);
+    const light = Math.max(l1, l2);
+    const dark = Math.min(l1, l2);
+    return (light + 0.05) / (dark + 0.05);
+  };
+  const ensureReadable = (color, background, reference, minRatio = 4.5) => {
+    const bg = background || FALLBACK.background;
+    const base = color || reference || FALLBACK.text;
+    if (contrastRatio(base, bg) >= minRatio) return base;
+    const target = reference || pickInk(bg);
+    const steps = [0.25, 0.5, 0.75, 1];
+    for (const step of steps) {
+      const candidate = mix(base, target, step);
+      if (contrastRatio(candidate, bg) >= minRatio) return candidate;
+    }
+    return pickInk(bg);
+  };
 
   const FALLBACK = {
     background: parseColor("#0b0f12"),
@@ -127,17 +146,28 @@
     const shadow = mix(text, bg, 0.12);
     const scrollThumb = mix(text, bg, 0.7);
 
+    const readableText = ensureReadable(text, panel, text, 4.5);
+    const readableMuted = ensureReadable(textMuted, panel, readableText, 3.2);
+    const readableSys = ensureReadable(sys, surface, readableText, 4.5);
+    const readableInbound = ensureReadable(inbound, surface, readableText, 4.5);
+    const readableError = ensureReadable(error, surface, readableText, 4.5);
+    const readableStatusIdle = ensureReadable(statusIdle, surface, readableMuted, 3.5);
+    const readableStatusConnecting = ensureReadable(statusConnecting, surface, readableSys, 4.5);
+    const readableStatusConnected = ensureReadable(statusConnected, surface, readableSys, 4.5);
+    const readableStatusError = ensureReadable(error, surface, readableError, 4.5);
+    const readablePrimaryText = ensureReadable(accentInk, btnPrimaryBg, pickInk(btnPrimaryBg), 4.5);
+
     target.style.setProperty("--mud-bg", toRgbString(surface, FALLBACK.background));
     target.style.setProperty("--mud-panel", toRgbString(panel, FALLBACK.background));
     target.style.setProperty("--mud-panel-strong", toRgbString(panelStrong, FALLBACK.background));
     target.style.setProperty("--mud-input-bg", toRgbString(inputBg, FALLBACK.background));
     target.style.setProperty("--mud-border", toRgbString(border, FALLBACK.border));
     target.style.setProperty("--mud-border-strong", toRgbString(borderStrong, FALLBACK.border));
-    target.style.setProperty("--mud-text", toRgbString(text, FALLBACK.text));
-    target.style.setProperty("--mud-text-muted", toRgbString(textMuted, FALLBACK.text));
-    target.style.setProperty("--mud-sys", toRgbString(sys, FALLBACK.text));
-    target.style.setProperty("--mud-in", toRgbString(inbound, FALLBACK.accent));
-    target.style.setProperty("--mud-err", toRgbString(error, FALLBACK.error));
+    target.style.setProperty("--mud-text", toRgbString(readableText, FALLBACK.text));
+    target.style.setProperty("--mud-text-muted", toRgbString(readableMuted, FALLBACK.text));
+    target.style.setProperty("--mud-sys", toRgbString(readableSys, FALLBACK.text));
+    target.style.setProperty("--mud-in", toRgbString(readableInbound, FALLBACK.accent));
+    target.style.setProperty("--mud-err", toRgbString(readableError, FALLBACK.error));
     target.style.setProperty("--mud-btn-bg", toRgbString(btnBg, FALLBACK.background));
     target.style.setProperty("--mud-btn-hover-bg", toRgbString(btnHoverBg, FALLBACK.background));
     target.style.setProperty("--mud-btn-border", toRgbString(btnBorder, FALLBACK.border));
@@ -145,11 +175,11 @@
     target.style.setProperty("--mud-btn-primary-hover-bg", toRgbString(btnPrimaryHoverBg, FALLBACK.accent));
     target.style.setProperty("--mud-btn-primary-border", toRgbString(btnPrimaryBorder, FALLBACK.accent));
     target.style.setProperty("--mud-btn-primary-hover-border", toRgbString(btnPrimaryHoverBorder, FALLBACK.accent));
-    target.style.setProperty("--mud-btn-primary-text", toRgbString(accentInk || pickInk(btnPrimaryBg), FALLBACK.accentInk));
-    target.style.setProperty("--mud-status-idle", toRgbString(statusIdle, FALLBACK.text));
-    target.style.setProperty("--mud-status-connecting", toRgbString(statusConnecting, FALLBACK.accent));
-    target.style.setProperty("--mud-status-connected", toRgbString(statusConnected, FALLBACK.accent));
-    target.style.setProperty("--mud-status-error", toRgbString(error, FALLBACK.error));
+    target.style.setProperty("--mud-btn-primary-text", toRgbString(readablePrimaryText, FALLBACK.accentInk));
+    target.style.setProperty("--mud-status-idle", toRgbString(readableStatusIdle, FALLBACK.text));
+    target.style.setProperty("--mud-status-connecting", toRgbString(readableStatusConnecting, FALLBACK.accent));
+    target.style.setProperty("--mud-status-connected", toRgbString(readableStatusConnected, FALLBACK.accent));
+    target.style.setProperty("--mud-status-error", toRgbString(readableStatusError, FALLBACK.error));
     target.style.setProperty("--mud-gap-color", toRgbString(gap, FALLBACK.border));
     target.style.setProperty("--mud-shadow", toRgbaString(shadow, 0.35, FALLBACK.text));
     target.style.setProperty("--mud-scroll-thumb", toRgbaString(scrollThumb, 0.4, FALLBACK.text));

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -14,6 +14,189 @@
 
   let controller = null; // singleton overlay controller
 
+  // ---------- theme sync ----------
+  const themeTargets = new Set();
+  let themeObserver = null;
+  let themeListenersBound = false;
+
+  const clamp = (value, min = 0, max = 255) => Math.min(max, Math.max(min, Number.isFinite(value) ? value : 0));
+  const parseColor = (value) => {
+    if (!value && value !== 0) return null;
+    const raw = String(value).trim();
+    if (!raw) return null;
+    if (raw.startsWith("#")) {
+      let hex = raw.slice(1);
+      if (hex.length === 3) hex = hex.split("").map((c) => c + c).join("");
+      if (hex.length >= 6) {
+        const r = parseInt(hex.slice(0, 2), 16);
+        const g = parseInt(hex.slice(2, 4), 16);
+        const b = parseInt(hex.slice(4, 6), 16);
+        if ([r, g, b].every((c) => Number.isFinite(c))) return { r, g, b };
+      }
+      return null;
+    }
+    const rgb = raw.match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)(?:\s*,\s*([\d.]+))?\s*\)$/i);
+    if (rgb) {
+      return {
+        r: clamp(Math.round(parseFloat(rgb[1]))),
+        g: clamp(Math.round(parseFloat(rgb[2]))),
+        b: clamp(Math.round(parseFloat(rgb[3]))),
+      };
+    }
+    return null;
+  };
+  const toRgbString = (color, fallback) => {
+    const base = color || fallback;
+    if (!base) return "";
+    return `rgb(${clamp(Math.round(base.r))}, ${clamp(Math.round(base.g))}, ${clamp(Math.round(base.b))})`;
+  };
+  const toRgbaString = (color, alpha = 1, fallback) => {
+    const base = color || fallback;
+    const a = clamp(Number.isFinite(alpha) ? alpha : 1, 0, 1);
+    if (!base) return `rgba(0, 0, 0, ${a})`;
+    return `rgba(${clamp(Math.round(base.r))}, ${clamp(Math.round(base.g))}, ${clamp(Math.round(base.b))}, ${a})`;
+  };
+  const mix = (a, b, amount) => {
+    const c1 = a || FALLBACK.background;
+    const c2 = b || FALLBACK.text;
+    const t = clamp(Number.isFinite(amount) ? amount : 0, 0, 1);
+    return {
+      r: clamp(Math.round(c1.r + (c2.r - c1.r) * t)),
+      g: clamp(Math.round(c1.g + (c2.g - c1.g) * t)),
+      b: clamp(Math.round(c1.b + (c2.b - c1.b) * t)),
+    };
+  };
+  const relativeLuminance = (color) => {
+    const c = color || FALLBACK.text;
+    const norm = [c.r, c.g, c.b].map((v) => {
+      const srgb = clamp(v) / 255;
+      return srgb <= 0.03928 ? srgb / 12.92 : Math.pow((srgb + 0.055) / 1.055, 2.4);
+    });
+    return 0.2126 * norm[0] + 0.7152 * norm[1] + 0.0722 * norm[2];
+  };
+  const DARK_INK = { r: 15, g: 17, b: 21 };
+  const LIGHT_INK = { r: 255, g: 255, b: 255 };
+  const pickInk = (color) => (relativeLuminance(color) > 0.55 ? DARK_INK : LIGHT_INK);
+
+  const FALLBACK = {
+    background: parseColor("#0b0f12"),
+    text: parseColor("#e6edf3"),
+    accent: parseColor("#29e3c7"),
+    accentInk: DARK_INK,
+    error: parseColor("#ff7b72"),
+    border: parseColor("#2d3741"),
+  };
+
+  function computePalette() {
+    const style = getComputedStyle(document.documentElement);
+    const background = parseColor(style.getPropertyValue("--background-color")) || FALLBACK.background;
+    const text = parseColor(style.getPropertyValue("--font-color")) || FALLBACK.text;
+    const accent =
+      parseColor(style.getPropertyValue("--accent")) ||
+      parseColor(style.getPropertyValue("--primary-color")) ||
+      FALLBACK.accent;
+    const accentInk = parseColor(style.getPropertyValue("--accent-ink")) || (accent ? pickInk(accent) : FALLBACK.accentInk);
+    const error = parseColor(style.getPropertyValue("--error-color")) || FALLBACK.error;
+    return { background, text, accent, accentInk, error };
+  }
+
+  function applyThemeVars(target) {
+    if (!target) return;
+    const { background: bg, text, accent, accentInk, error } = computePalette();
+    const surface = mix(bg, text, 0.08);
+    const panel = mix(bg, text, 0.14);
+    const panelStrong = mix(bg, text, 0.18);
+    const border = mix(bg, text, 0.22);
+    const borderStrong = mix(bg, text, 0.34);
+    const inputBg = mix(bg, text, 0.1);
+    const textMuted = mix(text, bg, 0.5);
+    const sys = mix(text, accent, 0.35);
+    const inbound = mix(accent, text, 0.45);
+    const gap = mix(bg, text, 0.2);
+    const btnBg = mix(bg, text, 0.14);
+    const btnHoverBg = mix(bg, text, 0.22);
+    const btnBorder = border;
+    const btnPrimaryBg = mix(bg, accent, 0.42);
+    const btnPrimaryHoverBg = mix(bg, accent, 0.52);
+    const btnPrimaryBorder = mix(btnPrimaryBg, accent, 0.3);
+    const btnPrimaryHoverBorder = mix(btnPrimaryHoverBg, accent, 0.35);
+    const focusRing = mix(accent, text, 0.3);
+    const statusIdle = mix(text, bg, 0.45);
+    const statusConnecting = mix(accent, text, 0.6);
+    const statusConnected = mix(accent, text, 0.4);
+    const shadow = mix(text, bg, 0.12);
+    const scrollThumb = mix(text, bg, 0.7);
+
+    target.style.setProperty("--mud-bg", toRgbString(surface, FALLBACK.background));
+    target.style.setProperty("--mud-panel", toRgbString(panel, FALLBACK.background));
+    target.style.setProperty("--mud-panel-strong", toRgbString(panelStrong, FALLBACK.background));
+    target.style.setProperty("--mud-input-bg", toRgbString(inputBg, FALLBACK.background));
+    target.style.setProperty("--mud-border", toRgbString(border, FALLBACK.border));
+    target.style.setProperty("--mud-border-strong", toRgbString(borderStrong, FALLBACK.border));
+    target.style.setProperty("--mud-text", toRgbString(text, FALLBACK.text));
+    target.style.setProperty("--mud-text-muted", toRgbString(textMuted, FALLBACK.text));
+    target.style.setProperty("--mud-sys", toRgbString(sys, FALLBACK.text));
+    target.style.setProperty("--mud-in", toRgbString(inbound, FALLBACK.accent));
+    target.style.setProperty("--mud-err", toRgbString(error, FALLBACK.error));
+    target.style.setProperty("--mud-btn-bg", toRgbString(btnBg, FALLBACK.background));
+    target.style.setProperty("--mud-btn-hover-bg", toRgbString(btnHoverBg, FALLBACK.background));
+    target.style.setProperty("--mud-btn-border", toRgbString(btnBorder, FALLBACK.border));
+    target.style.setProperty("--mud-btn-primary-bg", toRgbString(btnPrimaryBg, FALLBACK.accent));
+    target.style.setProperty("--mud-btn-primary-hover-bg", toRgbString(btnPrimaryHoverBg, FALLBACK.accent));
+    target.style.setProperty("--mud-btn-primary-border", toRgbString(btnPrimaryBorder, FALLBACK.accent));
+    target.style.setProperty("--mud-btn-primary-hover-border", toRgbString(btnPrimaryHoverBorder, FALLBACK.accent));
+    target.style.setProperty("--mud-btn-primary-text", toRgbString(accentInk || pickInk(btnPrimaryBg), FALLBACK.accentInk));
+    target.style.setProperty("--mud-status-idle", toRgbString(statusIdle, FALLBACK.text));
+    target.style.setProperty("--mud-status-connecting", toRgbString(statusConnecting, FALLBACK.accent));
+    target.style.setProperty("--mud-status-connected", toRgbString(statusConnected, FALLBACK.accent));
+    target.style.setProperty("--mud-status-error", toRgbString(error, FALLBACK.error));
+    target.style.setProperty("--mud-gap-color", toRgbString(gap, FALLBACK.border));
+    target.style.setProperty("--mud-shadow", toRgbaString(shadow, 0.35, FALLBACK.text));
+    target.style.setProperty("--mud-scroll-thumb", toRgbaString(scrollThumb, 0.4, FALLBACK.text));
+    target.style.setProperty("--mud-focus-ring", toRgbaString(focusRing, 0.35, FALLBACK.accent));
+  }
+
+  function refreshThemeTargets() {
+    for (const target of Array.from(themeTargets)) {
+      if (!target || !target.isConnected) {
+        themeTargets.delete(target);
+        continue;
+      }
+      applyThemeVars(target);
+    }
+  }
+
+  function ensureThemeWatcher() {
+    const root = document.documentElement;
+    if (!themeObserver) {
+      themeObserver = new MutationObserver(refreshThemeTargets);
+      themeObserver.observe(root, { attributes: true, attributeFilter: ["data-theme", "style"] });
+    }
+    if (!themeListenersBound) {
+      themeListenersBound = true;
+      try {
+        const mq = window.matchMedia ? window.matchMedia("(prefers-color-scheme: dark)") : null;
+        if (mq && typeof mq.addEventListener === "function") mq.addEventListener("change", refreshThemeTargets);
+        else if (mq && typeof mq.addListener === "function") mq.addListener(refreshThemeTargets);
+      } catch {}
+      window.addEventListener(
+        "storage",
+        (e) => {
+          if (!e) return;
+          if (e.key === "site:theme" || e.key === "site:accent" || e.key === "site:accentInk") refreshThemeTargets();
+        },
+        { passive: true }
+      );
+    }
+  }
+
+  function registerThemeTarget(target) {
+    if (!target) return;
+    themeTargets.add(target);
+    applyThemeVars(target);
+    ensureThemeWatcher();
+  }
+
   // ---------- utils ----------
   const now = () => new Date().toLocaleTimeString();
   const el = (tag, attrs = {}, children = []) => {
@@ -34,43 +217,173 @@
     if (document.getElementById(STYLE_ID)) return;
     const css = `
 #${OVERLAY_ID}{
-  position:fixed;right:12px;bottom:12px;width:min(700px,95vw);height:min(60vh,70vh);
-  z-index:2147483647;font-family:ui-monospace,Menlo,Consolas,monospace;
-  background:#0b0f12;color:#e6edf3;border:1px solid #2d3741;border-radius:10px;
-  box-shadow:0 10px 30px rgba(0,0,0,.5);display:flex;flex-direction:column;overflow:hidden;resize:both
+  position:fixed;
+  right:12px;
+  bottom:12px;
+  width:min(700px,95vw);
+  height:min(60vh,70vh);
+  z-index:2147483647;
+  font-family:ui-monospace,Menlo,Consolas,monospace;
+  background:var(--mud-panel,var(--mud-bg,#0b0f12));
+  color:var(--mud-text,#e6edf3);
+  border:1px solid var(--mud-border,#2d3741);
+  border-radius:12px;
+  box-shadow:0 12px 36px var(--mud-shadow,rgba(15,17,21,.6));
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+  resize:both;
 }
 #${OVERLAY_ID} .head{
-  display:flex;gap:8px;align-items:center;padding:8px;background:#0f1419;border-bottom:1px solid #2d3741
+  display:flex;
+  gap:8px;
+  align-items:center;
+  padding:10px;
+  background:var(--mud-panel,#0f1419);
+  border-bottom:1px solid var(--mud-border,#2d3741);
 }
-#${OVERLAY_ID} .status{padding:6px 10px;border:1px solid #2d3741;border-radius:8px;background:#192129}
+#${OVERLAY_ID} .status{
+  padding:6px 10px;
+  border:1px solid var(--mud-border,#2d3741);
+  border-radius:999px;
+  background:var(--mud-bg,#0b0f12);
+  color:var(--mud-status-idle,#9da7b3);
+  font-size:13px;
+  line-height:1;
+  display:inline-flex;
+  align-items:center;
+  gap:6px;
+  transition:color .15s ease,border-color .15s ease,background-color .15s ease;
+}
+#${OVERLAY_ID} .status.status-connecting{color:var(--mud-status-connecting,#d29922);}
+#${OVERLAY_ID} .status.status-connected{color:var(--mud-status-connected,#3fb950);}
+#${OVERLAY_ID} .status.status-error{
+  color:var(--mud-status-error,#ff7b72);
+  border-color:var(--mud-status-error,#ff7b72);
+}
 #${OVERLAY_ID} .url{
-  flex:1;background:#0b0f12;color:#e6edf3;border:1px solid #2d3741;border-radius:8px;padding:6px 8px
+  flex:1;
+  background:var(--mud-input-bg,#0b0f12);
+  color:var(--mud-text,#e6edf3);
+  border:1px solid var(--mud-border,#2d3741);
+  border-radius:10px;
+  padding:8px 10px;
+  font-size:13px;
+  line-height:1.3;
+  transition:border-color .15s ease,box-shadow .15s ease;
+}
+#${OVERLAY_ID} .url:focus-visible{
+  outline:none;
+  border-color:var(--mud-border-strong,#3b4855);
+  box-shadow:0 0 0 3px var(--mud-focus-ring,rgba(41,227,199,.35));
 }
 #${OVERLAY_ID} .btn{
-  background:#192129;color:#e6edf3;border:1px solid #2d3741;border-radius:8px;padding:6px 10px;cursor:pointer
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  gap:6px;
+  background:var(--mud-btn-bg,#192129);
+  color:var(--mud-text,#e6edf3);
+  border:1px solid var(--mud-btn-border,#2d3741);
+  border-radius:10px;
+  padding:8px 12px;
+  font-size:13px;
+  line-height:1.1;
+  cursor:pointer;
+  transition:background-color .15s ease,border-color .15s ease,color .15s ease,transform .1s ease;
 }
-#${OVERLAY_ID} .btn:hover{background:#1f2a33}
+#${OVERLAY_ID} .btn:hover{
+  background:var(--mud-btn-hover-bg,#1f2a33);
+  border-color:var(--mud-border-strong,#3b4855);
+}
+#${OVERLAY_ID} .btn:focus-visible{
+  outline:none;
+  border-color:var(--mud-border-strong,#3b4855);
+  box-shadow:0 0 0 3px var(--mud-focus-ring,rgba(41,227,199,.35));
+}
+#${OVERLAY_ID} .btn:active{transform:translateY(1px);}
+#${OVERLAY_ID} .btn-primary{
+  background:var(--mud-btn-primary-bg,#1f4b47);
+  border-color:var(--mud-btn-primary-border,#2e605a);
+  color:var(--mud-btn-primary-text,#0f1115);
+}
+#${OVERLAY_ID} .btn-primary:hover{
+  background:var(--mud-btn-primary-hover-bg,#225f58);
+  border-color:var(--mud-btn-primary-hover-border,var(--mud-btn-primary-border,#2e605a));
+}
+#${OVERLAY_ID} .btn-muted{
+  background:transparent;
+  color:var(--mud-text-muted,#9da7b3);
+  border-color:var(--mud-border,#2d3741);
+}
+#${OVERLAY_ID} .btn-muted:hover{
+  background:var(--mud-panel-strong,var(--mud-panel,#0f1419));
+  color:var(--mud-text,#e6edf3);
+}
+#${OVERLAY_ID} .btn-icon{
+  width:40px;
+  padding:8px 0;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+}
 #${OVERLAY_ID} .out{
-  white-space:pre-wrap;line-height:1.35;padding:8px 10px;height:100%;overflow:auto;font-size:13px
+  white-space:pre-wrap;
+  line-height:1.35;
+  padding:12px 14px;
+  height:100%;
+  overflow:auto;
+  font-size:13px;
+  background:var(--mud-bg,#0b0f12);
+  border-bottom:1px solid var(--mud-border,#2d3741);
+}
+#${OVERLAY_ID} .out::-webkit-scrollbar{width:10px;}
+#${OVERLAY_ID} .out::-webkit-scrollbar-thumb{
+  background:var(--mud-scroll-thumb,rgba(150,150,150,.35));
+  border-radius:999px;
 }
 #${OVERLAY_ID} .in{
-  display:grid;grid-template-columns:1fr auto auto;gap:8px;padding:8px;border-top:1px solid #2d3741;background:#0f1419
+  display:grid;
+  grid-template-columns:1fr auto auto;
+  gap:8px;
+  padding:10px;
+  border-top:1px solid var(--mud-border,#2d3741);
+  background:var(--mud-panel-strong,var(--mud-panel,#0f1419));
 }
 #${OVERLAY_ID} textarea{
-  height:56px;resize:none;background:#0b0f12;color:#e6edf3;border:1px solid #2d3741;border-radius:8px;padding:8px;font:13px inherit
+  height:56px;
+  resize:none;
+  background:var(--mud-input-bg,#0b0f12);
+  color:var(--mud-text,#e6edf3);
+  border:1px solid var(--mud-border,#2d3741);
+  border-radius:10px;
+  padding:10px;
+  font:13px/1.3 inherit;
+  transition:border-color .15s ease,box-shadow .15s ease;
 }
-#${OVERLAY_ID} .sys{color:#9da7b3}
-#${OVERLAY_ID} .err{color:#ff7b72}
-#${OVERLAY_ID} .inl{color:#79c0ff}
-#${OVERLAY_ID} .outl{color:#a5d6a7}
+#${OVERLAY_ID} textarea:focus-visible{
+  outline:none;
+  border-color:var(--mud-border-strong,#3b4855);
+  box-shadow:0 0 0 3px var(--mud-focus-ring,rgba(41,227,199,.35));
+}
+#${OVERLAY_ID} .sys{color:var(--mud-sys,#9da7b3);}
+#${OVERLAY_ID} .err{color:var(--mud-err,#ff7b72);}
+#${OVERLAY_ID} .inl{color:var(--mud-in,#79c0ff);}
+#${OVERLAY_ID} .outl{color:var(--mud-text,#e6edf3);}
+#${OVERLAY_ID} .gap{
+  margin:8px 0;
+  border-top:1px dashed var(--mud-gap-color,rgba(100,110,120,.4));
+}
 #${OVERLAY_ID}.embedded{
-  position: static;           /* no fixed positioning */
-  right: auto; bottom: auto;
-  width: 100%;                /* fill the container width */
-  max-width: none;
-  height: 60vh;               /* pick a comfortable height */
-  margin: 16px 0 0 0;         /* space above */
-  resize: vertical;           /* only vertical resize so it stays in width */
+  position:static;
+  right:auto;
+  bottom:auto;
+  width:100%;
+  max-width:none;
+  height:60vh;
+  margin:16px 0 0;
+  resize:vertical;
+  box-shadow:none;
 }`;
     const style = el("style", { id: STYLE_ID }, css);
     document.head.appendChild(style);
@@ -97,9 +410,11 @@
       root.classList.remove("embedded");
     }
 
+    registerThemeTarget(root);
+
     root.innerHTML = ""; // clean slate
     // Header
-    const statusEl = el("span", { class: "status" }, "● disconnected");
+    const statusEl = el("span", { class: "status status-idle", role: "status", "aria-live": "polite" }, "● disconnected");
     const savedUrl = localStorage.getItem(LS_KEY) || "";
     const linkUrl =
       savedUrl ||
@@ -111,16 +426,20 @@
       placeholder: "ws://host:port/path",
       value: linkUrl,
     });
-    const btnConn = el("button", { class: "btn" }, "Connect");
-    const btnClose = el("button", { class: "btn" }, "✕");
+    const btnConn = el("button", { class: "btn btn-primary", type: "button" }, "Connect");
+    const btnClose = el(
+      "button",
+      { class: "btn btn-icon btn-muted", type: "button", title: "Close overlay", "aria-label": "Close overlay" },
+      "✕"
+    );
 
     const head = el("div", { class: "head" }, [statusEl, urlEl, btnConn, btnClose]);
 
     // Output + input
     const out = el("div", { class: "out" });
     const input = el("textarea", { class: "input", placeholder: "Type… (Enter=send, Ctrl+Enter=newline, /clear, /help)" });
-    const btnSend = el("button", { class: "btn" }, "Send");
-    const btnClear = el("button", { class: "btn" }, "Clear");
+    const btnSend = el("button", { class: "btn btn-primary", type: "button" }, "Send");
+    const btnClear = el("button", { class: "btn btn-muted", type: "button" }, "Clear");
     const inputBar = el("div", { class: "in" }, [input, btnSend, btnClear]);
 
     root.appendChild(head);
@@ -133,10 +452,11 @@
     let idx = -1;
 
     // helpers
-    const setStatus = (txt, color) => {
+    const setStatus = (txt, state = "idle") => {
       statusEl.textContent = `● ${txt}`;
-      statusEl.style.color = color || "#e6edf3";
+      statusEl.className = `status${state ? ` status-${state}` : ""}`;
     };
+    setStatus("disconnected", "idle");
     // Coalesce fast bursts (e.g., multi-line help) into one timestamped block.
     let grpBuf = "";
     let grpCls = null;
@@ -176,6 +496,12 @@
       if (ws && ws.readyState === WebSocket.OPEN) ws.close(1000, "client closing");
     };
 
+    const closeOverlay = () => {
+      disconnect();
+      themeTargets.delete(root);
+      root.remove();
+    };
+
     const connect = () => {
       const url = (urlEl.value || "").trim();
       if (!url) {
@@ -185,14 +511,14 @@
       try {
         ws?.close();
       } catch {}
-      setStatus("connecting", "#d29922");
+      setStatus("connecting", "connecting");
       append(`Connecting to ${url} …`, "sys");
       ws = new WebSocket(url);
       localStorage.setItem(LS_KEY, url);
 
       ws.addEventListener("open", () => {
         flushGroup();
-        setStatus("connected", "#3fb950");
+        setStatus("connected", "connected");
         btnConn.textContent = "Disconnect";
         append("Connected.", "sys");
         input.focus();
@@ -210,20 +536,20 @@
             return;
           }
           if (!s || !s.trim()) return; // drop empty/whitespace-only payloads
-          +append(s, "outl");
+          append(s, "outl");
         } catch (e) {
           append("Message handling error: " + (e?.message || e), "err");
         }
       });
       ws.addEventListener("error", (e) => {
         flushGroup();
-        setStatus("error", "#ff7b72");
+        setStatus("error", "error");
         append("WebSocket error (see console).", "err");
         console.error("[MUD WS] error", e);
       });
       ws.addEventListener("close", (e) => {
         flushGroup();
-        setStatus("disconnected", "#ff7b72");
+        setStatus("disconnected", "idle");
         btnConn.textContent = "Connect";
         append(`Disconnected (code ${e.code}).`, "sys");
       });
@@ -278,10 +604,7 @@
       } else connect();
     });
 
-    btnClose.addEventListener("click", () => {
-      disconnect();
-      root.remove();
-    });
+    btnClose.addEventListener("click", closeOverlay);
 
     btnSend.addEventListener("click", send);
     btnClear.addEventListener("click", () => (out.innerHTML = ""));
@@ -299,8 +622,7 @@
         send();
       }
       if (e.key === "Escape") {
-        disconnect();
-        root.remove();
+        closeOverlay();
       }
       if (e.key === "ArrowUp") {
         if (idx > 0) {


### PR DESCRIPTION
## Summary
- derive overlay colors from the blog's CSS variables and react to theme or accent changes
- restyle the injected overlay CSS to use theme-driven custom properties for controls and output
- update the overlay markup to register for theme sync, add accessible status text, and refine button behavior

## Testing
- node --check static/js/mud-overlay.js

------
https://chatgpt.com/codex/tasks/task_e_68d0a66379608320a846b9c1da765364