### PR TITLE
Add optional auto-launch for MUD overlay

### DIFF
--- a/content/projects/dmud/index.md
+++ b/content/projects/dmud/index.md
@@ -2,6 +2,7 @@
 title = "DMUD"
 date = "2025-08-10"
 mud_overlay = true
+mud_autostart = true
 tag_line = "I've been learning GO by building a really basic MUD [github](https://github.com/dustywusty/dmud)"
 +++
 

--- a/layouts/partials/mud-overlay.html
+++ b/layouts/partials/mud-overlay.html
@@ -3,29 +3,87 @@
 (function(){
   if (window.__mud_loader) return; window.__mud_loader = true;
   var src = document.currentScript && document.currentScript.getAttribute('data-mud-src') || "{{ "js/mud-overlay.js" | relURL }}";
+  var pendingUrl = null;
+  var pendingAnchor = null;
+  var loading = false;
 
   function findLink(t){ return t && t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]'); }
+  function findFirstLink(){
+    var links = document.querySelectorAll('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    for (var i = 0; i < links.length; i++) {
+      var skip = links[i].getAttribute('data-mud-autostart');
+      if (skip && skip.toLowerCase() === 'false') continue;
+      return links[i];
+    }
+    return null;
+  }
   function resolveUrl(a){
+    if (!a) return '';
     var u = a.getAttribute('data-mud-ws') || '';
     if (!u) { var href = a.getAttribute('href')||''; if (/^wss?:\/\//i.test(href)) u = href; }
     var p = a.getAttribute('data-mud-path');
     if (!u && p) u = (location.protocol==='https:'?'wss://':'ws://') + location.host + p;
     return u;
   }
+  function summon(url, anchor){
+    if (!url) return;
+    var targetAnchor = anchor && anchor.nodeType === 1 ? anchor : null;
+    if (window.spawnMudOverlay) {
+      if (targetAnchor) {
+        window.spawnMudOverlay(url, { anchor: targetAnchor });
+      } else {
+        window.spawnMudOverlay(url);
+      }
+      return;
+    }
+
+    pendingUrl = url;
+    pendingAnchor = targetAnchor;
+    if (loading) return;
+
+    loading = true;
+    var s = document.createElement('script');
+    s.src = src; s.defer = true;
+    s.onload  = function(){
+      loading = false;
+      var target = pendingUrl; pendingUrl = null;
+      var anchor = pendingAnchor; pendingAnchor = null;
+      if (window.spawnMudOverlay && target) {
+        if (anchor) {
+          window.spawnMudOverlay(target, { anchor: anchor });
+        } else {
+          window.spawnMudOverlay(target);
+        }
+      }
+    };
+    s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
+    document.head.appendChild(s);
+  }
 
   document.addEventListener('click', function(e){
     var a = findLink(e.target); if (!a) return;
     var url = resolveUrl(a);    if (!url) return;
     e.preventDefault();
-
-    if (window.spawnMudOverlay) { window.spawnMudOverlay(url); return; }
-
-    var s = document.createElement('script');
-    s.src = src; s.defer = true;
-    s.onload  = function(){ window.spawnMudOverlay && window.spawnMudOverlay(url); };
-    s.onerror = function(){ console.error('Failed to load MUD overlay script at', src); };
-    document.head.appendChild(s);
+    summon(url, a);
   }, { capture: true });
+
+  var autoLaunch = {{ if or .Params.mud_autostart .Site.Params.mud_autostart }}true{{ else }}false{{ end }};
+  var explicitUrl = {{ with or .Params.mud_ws .Site.Params.mud_ws }}{{ printf "%q" . }}{{ else }}null{{ end }};
+
+  if (autoLaunch) {
+    var targetUrl = explicitUrl;
+    if (!targetUrl) {
+      var link = findFirstLink();
+      targetUrl = resolveUrl(link) || null;
+    }
+    if (targetUrl) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });
+      } else {
+        summon(targetUrl, link);
+      }
+    }
+  }
 })();
 </script>
 {{ end }}

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -11,8 +11,9 @@
   const SEND_NL = true; // newline-terminate commands
   const LS_KEY = "mud_ws_url";
   const MOUNT_SELECTOR = ".container.animate-fade-up";
-
+  
   let controller = null; // singleton overlay controller
+  let lastAnchor = null;
 
   // ---------- theme sync ----------
   const themeTargets = new Set();
@@ -420,25 +421,53 @@
   }
 
   // ---------- overlay builder ----------
-  function buildOverlay() {
-    ensureStyles();
+  function extractUrlFromLink(link) {
+    if (!link) return "";
+    const explicit = link.getAttribute("data-mud-ws") || link.getAttribute("data-mud") || "";
+    if (explicit) return explicit;
+    const href = link.getAttribute("href") || "";
+    if (/^wss?:\/\//i.test(href)) return href;
+    const path = link.getAttribute("data-mud-path");
+    if (path) {
+      const base = location.protocol === "https:" ? "wss://" : "ws://";
+      return `${base}${location.host}${path}`;
+    }
+    return "";
+  }
 
-    // Find blog container (your <div class="container animate-fade-up">)
-    const mount = document.querySelector(MOUNT_SELECTOR);
+  function placeOverlay(root, anchor) {
+    const usableAnchor = anchor && anchor.nodeType === 1 && anchor.isConnected ? anchor : null;
+    let inserted = false;
+    if (usableAnchor) {
+      const block = usableAnchor.closest(
+        "[data-mud-mount],p,div,section,article,li,dd,dt,main,aside,header,footer,figure"
+      );
+      if (block && block.parentNode) {
+        block.insertAdjacentElement("afterend", root);
+        root.classList.add("embedded");
+        inserted = true;
+      }
+    }
+    if (!inserted) {
+      const fallback = document.querySelector(MOUNT_SELECTOR) || document.body;
+      if (root.parentNode !== fallback) {
+        fallback.appendChild(root);
+      }
+      if (fallback === document.body) root.classList.remove("embedded");
+      else root.classList.add("embedded");
+    }
+    lastAnchor = inserted ? usableAnchor : null;
+  }
+
+  function buildOverlay(anchor) {
+    ensureStyles();
 
     let root = document.getElementById(OVERLAY_ID);
     if (!root) {
       root = el("div", { id: OVERLAY_ID });
     }
 
-    // Move (or place) the overlay into the mount when present; fall back to body otherwise
-    if (mount) {
-      if (root.parentNode !== mount) mount.appendChild(root); // ends up below your header/link
-      root.classList.add("embedded");
-    } else {
-      if (!root.parentNode) document.body.appendChild(root);
-      root.classList.remove("embedded");
-    }
+    placeOverlay(root, anchor);
 
     registerThemeTarget(root);
 
@@ -446,10 +475,8 @@
     // Header
     const statusEl = el("span", { class: "status status-idle", role: "status", "aria-live": "polite" }, "● disconnected");
     const savedUrl = localStorage.getItem(LS_KEY) || "";
-    const linkUrl =
-      savedUrl ||
-      (mount && mount.querySelector('a[href^="ws"]')?.href) || // picks up your wss://... link
-      "";
+    const contextualLink = anchor && anchor.isConnected ? anchor : document.querySelector('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    const linkUrl = savedUrl || extractUrlFromLink(contextualLink) || "";
     const urlEl = el("input", {
       class: "url",
       type: "text",
@@ -687,16 +714,19 @@
         urlEl.value = u || "";
       },
       focus: () => input.focus(),
+      place: (nextAnchor) => placeOverlay(root, nextAnchor || lastAnchor),
     };
   }
 
   // ---------- public API ----------
-  function spawn(initialUrl) {
+  function spawn(initialUrl, options) {
+    const anchor = options && options.anchor && options.anchor.nodeType === 1 ? options.anchor : lastAnchor;
     // build or reuse
     if (!controller || !document.body.contains(controller.root)) {
-      controller = buildOverlay();
+      controller = buildOverlay(anchor);
     } else {
       controller.root.style.display = "";
+      controller.place(anchor);
     }
 
     // bring to front
@@ -710,7 +740,11 @@
   }
 
   // Optional: support `document.dispatchEvent(new CustomEvent('mud:spawn', { detail: { url } }))`
-  document.addEventListener("mud:spawn", (e) => spawn(e?.detail?.url), { passive: true });
+  document.addEventListener(
+    "mud:spawn",
+    (e) => spawn(e?.detail?.url, e?.detail?.anchor ? { anchor: e.detail.anchor } : undefined),
+    { passive: true }
+  );
 
   // Expose for the lazy loader
   window.spawnMudOverlay = window.spawnMudOverlay || spawn;


### PR DESCRIPTION
## Summary
- allow the MUD overlay loader to reuse a shared spawn helper
- add optional front matter / site parameters to auto-launch the overlay with a preferred URL
- enable the DMUD project page to open the console automatically on page load
- ensure the overlay positions itself next to the triggering link when opened or autostarted

## Testing
- hugo *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e8ae569083209ad09af576786e60