### PR TITLE
Support hidden mount points for the MUD overlay

### DIFF
--- a/layouts/partials/mud-overlay.html
+++ b/layouts/partials/mud-overlay.html
@@ -7,9 +7,17 @@
   var pendingAnchor = null;
   var loading = false;
 
-  function findLink(t){ return t && t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]'); }
+  var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
+
+  function findLink(t){
+    if (!t) return null;
+    var link = t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    if (link) return link;
+    return t.closest('[data-mud-mount]');
+  }
+
   function findFirstLink(){
-    var links = document.querySelectorAll('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    var links = document.querySelectorAll(TRIGGER_SELECTOR);
     for (var i = 0; i < links.length; i++) {
       var skip = links[i].getAttribute('data-mud-autostart');
       if (skip && skip.toLowerCase() === 'false') continue;
@@ -61,7 +69,7 @@
   }
 
   document.addEventListener('click', function(e){
-    var a = findLink(e.target); if (!a) return;
+    var a = findLink(e.target); if (!a || a.tagName !== 'A') return;
     var url = resolveUrl(a);    if (!url) return;
     e.preventDefault();
     summon(url, a);
@@ -71,11 +79,8 @@
   var explicitUrl = {{ with or .Params.mud_ws .Site.Params.mud_ws }}{{ printf "%q" . }}{{ else }}null{{ end }};
 
   if (autoLaunch) {
-    var targetUrl = explicitUrl;
-    if (!targetUrl) {
-      var link = findFirstLink();
-      targetUrl = resolveUrl(link) || null;
-    }
+    var link = findFirstLink();
+    var targetUrl = explicitUrl || resolveUrl(link) || null;
     if (targetUrl) {
       if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });

--- a/layouts/shortcodes/mud-console.html
+++ b/layouts/shortcodes/mud-console.html
@@ -1,0 +1,19 @@
+{{- $class := .Get "class" | default "" -}}
+{{- $ws := .Get "ws" -}}
+{{- if not $ws -}}
+  {{- with .Page.Params.mud_ws -}}
+    {{- $ws = . -}}
+  {{- end -}}
+{{- end -}}
+{{- $path := .Get "path" -}}
+{{- if not $path -}}
+  {{- with .Page.Params.mud_path -}}
+    {{- $path = . -}}
+  {{- end -}}
+{{- end -}}
+{{- $show := .Get "show" -}}
+<div data-mud-mount
+     class="mud-console-mount{{ if $class }} {{ $class }}{{ end }}"
+     {{- if $ws }} data-mud-ws="{{ $ws }}"{{ end -}}
+     {{- if and (not $ws) $path }} data-mud-path="{{ $path }}"{{ end -}}
+     {{- if not $show }} hidden{{ end -}}></div>

--- a/public/js/mud-overlay.js
+++ b/public/js/mud-overlay.js
@@ -475,7 +475,10 @@
     // Header
     const statusEl = el("span", { class: "status status-idle", role: "status", "aria-live": "polite" }, "● disconnected");
     const savedUrl = localStorage.getItem(LS_KEY) || "";
-    const contextualLink = anchor && anchor.isConnected ? anchor : document.querySelector('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    const contextualLink =
+      anchor && anchor.isConnected
+        ? anchor
+        : document.querySelector('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]');
     const linkUrl = savedUrl || extractUrlFromLink(contextualLink) || "";
     const urlEl = el("input", {
       class: "url",

--- a/public/posts/learning-go-building-a-mud/index.html
+++ b/public/posts/learning-go-building-a-mud/index.html
@@ -218,29 +218,91 @@ Aug 10, 2025
 (function(){
   if (window.__mud_loader) return; window.__mud_loader = true;
   var src = document.currentScript && document.currentScript.getAttribute('data-mud-src') || "\/js\/mud-overlay.js";
+  var pendingUrl = null;
+  var pendingAnchor = null;
+  var loading = false;
 
-  function findLink(t){ return t && t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]'); }
+  var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
+
+  function findLink(t){
+    if (!t) return null;
+    var link = t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    if (link) return link;
+    return t.closest('[data-mud-mount]');
+  }
+  function findFirstLink(){
+    var links = document.querySelectorAll(TRIGGER_SELECTOR);
+    for (var i = 0; i < links.length; i++) {
+      var skip = links[i].getAttribute('data-mud-autostart');
+      if (skip && skip.toLowerCase() === 'false') continue;
+      return links[i];
+    }
+    return null;
+  }
   function resolveUrl(a){
+    if (!a) return '';
     var u = a.getAttribute('data-mud-ws') || '';
     if (!u) { var href = a.getAttribute('href')||''; if (/^wss?:\/\//i.test(href)) u = href; }
     var p = a.getAttribute('data-mud-path');
     if (!u && p) u = (location.protocol==='https:'?'wss://':'ws://') + location.host + p;
     return u;
   }
+  function summon(url, anchor){
+    if (!url) return;
+    var targetAnchor = anchor && anchor.nodeType === 1 ? anchor : null;
+    if (window.spawnMudOverlay) {
+      if (targetAnchor) {
+        window.spawnMudOverlay(url, { anchor: targetAnchor });
+      } else {
+        window.spawnMudOverlay(url);
+      }
+      return;
+    }
 
-  document.addEventListener('click', function(e){
-    var a = findLink(e.target); if (!a) return;
-    var url = resolveUrl(a);    if (!url) return;
-    e.preventDefault();
+    pendingUrl = url;
+    pendingAnchor = targetAnchor;
+    if (loading) return;
 
-    if (window.spawnMudOverlay) { window.spawnMudOverlay(url); return; }
-
+    loading = true;
     var s = document.createElement('script');
     s.src = src; s.defer = true;
-    s.onload  = function(){ window.spawnMudOverlay && window.spawnMudOverlay(url); };
-    s.onerror = function(){ console.error('Failed to load MUD overlay script at', src); };
+    s.onload  = function(){
+      loading = false;
+      var target = pendingUrl; pendingUrl = null;
+      var anchor = pendingAnchor; pendingAnchor = null;
+      if (window.spawnMudOverlay && target) {
+        if (anchor) {
+          window.spawnMudOverlay(target, { anchor: anchor });
+        } else {
+          window.spawnMudOverlay(target);
+        }
+      }
+    };
+    s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
     document.head.appendChild(s);
+  }
+
+  document.addEventListener('click', function(e){
+    var a = findLink(e.target); if (!a || a.tagName !== 'A') return;
+    var url = resolveUrl(a);    if (!url) return;
+    e.preventDefault();
+    summon(url, a);
   }, { capture: true });
+
+  var autoLaunch = false;
+  var explicitUrl = null;
+
+  if (autoLaunch) {
+    var link = findFirstLink();
+    var targetUrl = explicitUrl || resolveUrl(link) || null;
+    if (targetUrl) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });
+      } else {
+        summon(targetUrl, link);
+      }
+    }
+  }
 })();
 </script>
 

--- a/public/projects/dmud/index.html
+++ b/public/projects/dmud/index.html
@@ -211,9 +211,15 @@
   var pendingAnchor = null;
   var loading = false;
 
-  function findLink(t){ return t && t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]'); }
+  var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
+  function findLink(t){
+    if (!t) return null;
+    var link = t.closest('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    if (link) return link;
+    return t.closest('[data-mud-mount]');
+  }
   function findFirstLink(){
-    var links = document.querySelectorAll('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    var links = document.querySelectorAll(TRIGGER_SELECTOR);
     for (var i = 0; i < links.length; i++) {
       var skip = links[i].getAttribute('data-mud-autostart');
       if (skip && skip.toLowerCase() === 'false') continue;
@@ -265,7 +271,7 @@
   }
 
   document.addEventListener('click', function(e){
-    var a = findLink(e.target); if (!a) return;
+    var a = findLink(e.target); if (!a || a.tagName !== 'A') return;
     var url = resolveUrl(a);    if (!url) return;
     e.preventDefault();
     summon(url, a);
@@ -275,11 +281,8 @@
   var explicitUrl = null;
 
   if (autoLaunch) {
-    var targetUrl = explicitUrl;
-    if (!targetUrl) {
-      var link = findFirstLink();
-      targetUrl = resolveUrl(link) || null;
-    }
+    var link = findFirstLink();
+    var targetUrl = explicitUrl || resolveUrl(link) || null;
     if (targetUrl) {
       if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -475,7 +475,10 @@
     // Header
     const statusEl = el("span", { class: "status status-idle", role: "status", "aria-live": "polite" }, "● disconnected");
     const savedUrl = localStorage.getItem(LS_KEY) || "";
-    const contextualLink = anchor && anchor.isConnected ? anchor : document.querySelector('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"]');
+    const contextualLink =
+      anchor && anchor.isConnected
+        ? anchor
+        : document.querySelector('a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]');
     const linkUrl = savedUrl || extractUrlFromLink(contextualLink) || "";
     const urlEl = el("input", {
       class: "url",


### PR DESCRIPTION
## Summary
- allow the lazy loader to treat `[data-mud-mount]` placeholders as overlay anchors and reuse them on auto launch
- update the overlay script to look for mount placeholders when pre-filling the connection URL
- add a `mud-console` shortcode that emits a hidden mount div fed by front matter or shortcode parameters

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f044ed20832090947a3daff8f983