### PR TITLE
Fix DMUD autostart without manual link

### DIFF
--- a/content/projects/dmud/index.md
+++ b/content/projects/dmud/index.md
@@ -3,10 +3,11 @@ title = "DMUD"
 date = "2025-08-10"
 mud_overlay = true
 mud_autostart = true
+mud_path = "/mud"
 +++
 <!--more-->
 <br/>
 # Getting Started
 
-To clear the MUD console type "/clear" for in-game help type "help" -- to join click π
+The console should pop open automatically. To clear the MUD console type "/clear"; for in-game help type "help". If it doesn't launch on its own, click <a data-mud-path="/mud" href="#join-dmud" aria-label="Launch the DMUD console">π</a>.
 

--- a/layouts/partials/mud-overlay.html
+++ b/layouts/partials/mud-overlay.html
@@ -5,6 +5,7 @@
   var src = document.currentScript && document.currentScript.getAttribute('data-mud-src') || "{{ "js/mud-overlay.js" | relURL }}";
   var pendingUrl = null;
   var pendingAnchor = null;
+  var pendingForce = false;
   var loading = false;
 
   var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
@@ -33,20 +34,32 @@
     if (!u && p) u = (location.protocol==='https:'?'wss://':'ws://') + location.host + p;
     return u;
   }
-  function summon(url, anchor){
-    if (!url) return;
+  function pathToUrl(path){
+    if (!path) return '';
+    var raw = String(path).trim();
+    if (!raw) return '';
+    if (/^wss?:\/\//i.test(raw)) return raw;
+    if (raw.charAt(0) !== '/') raw = '/' + raw;
+    var scheme = location.protocol === 'https:' ? 'wss://' : 'ws://';
+    return scheme + location.host + raw;
+  }
+  function summon(url, anchor, options){
+    options = options || {};
+    var force = !!options.force;
+    if (!url && !force) return;
     var targetAnchor = anchor && anchor.nodeType === 1 ? anchor : null;
     if (window.spawnMudOverlay) {
-      if (targetAnchor) {
-        window.spawnMudOverlay(url, { anchor: targetAnchor });
-      } else {
-        window.spawnMudOverlay(url);
-      }
+      var spawnOptions = {};
+      if (targetAnchor) spawnOptions.anchor = targetAnchor;
+      if (force && !url) spawnOptions.deferConnect = true;
+      var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+      window.spawnMudOverlay(url || undefined, opts);
       return;
     }
 
     pendingUrl = url;
     pendingAnchor = targetAnchor;
+    pendingForce = force && !url;
     if (loading) return;
 
     loading = true;
@@ -56,12 +69,13 @@
       loading = false;
       var target = pendingUrl; pendingUrl = null;
       var anchor = pendingAnchor; pendingAnchor = null;
-      if (window.spawnMudOverlay && target) {
-        if (anchor) {
-          window.spawnMudOverlay(target, { anchor: anchor });
-        } else {
-          window.spawnMudOverlay(target);
-        }
+      var forceLaunch = pendingForce; pendingForce = false;
+      if (window.spawnMudOverlay) {
+        var spawnOptions = {};
+        if (anchor) spawnOptions.anchor = anchor;
+        if (forceLaunch && !target) spawnOptions.deferConnect = true;
+        var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+        window.spawnMudOverlay(target || undefined, opts);
       }
     };
     s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
@@ -77,15 +91,23 @@
 
   var autoLaunch = {{ if or .Params.mud_autostart .Site.Params.mud_autostart }}true{{ else }}false{{ end }};
   var explicitUrl = {{ with or .Params.mud_ws .Site.Params.mud_ws }}{{ printf "%q" . }}{{ else }}null{{ end }};
+  var explicitPath = {{ with or .Params.mud_path .Site.Params.mud_path }}{{ printf "%q" . }}{{ else }}null{{ end }};
 
   if (autoLaunch) {
     var link = findFirstLink();
-    var targetUrl = explicitUrl || resolveUrl(link) || null;
+    var targetUrl = explicitUrl || resolveUrl(link) || pathToUrl(explicitPath) || null;
+    var summonOptions = targetUrl ? null : { force: true };
     if (targetUrl) {
       if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });
       } else {
         summon(targetUrl, link);
+      }
+    } else if (summonOptions) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function(){ summon(null, link, summonOptions); }, { once: true });
+      } else {
+        summon(null, link, summonOptions);
       }
     }
   }

--- a/public/js/mud-overlay.js
+++ b/public/js/mud-overlay.js
@@ -724,6 +724,7 @@
   // ---------- public API ----------
   function spawn(initialUrl, options) {
     const anchor = options && options.anchor && options.anchor.nodeType === 1 ? options.anchor : lastAnchor;
+    const deferConnect = !!(options && options.deferConnect);
     // build or reuse
     if (!controller || !document.body.contains(controller.root)) {
       controller = buildOverlay(anchor);
@@ -737,7 +738,9 @@
     controller.root.style.zIndex = String(baseZ + 1);
 
     if (initialUrl) controller.setUrl(initialUrl);
-    controller.connect();
+    if (!deferConnect) {
+      controller.connect();
+    }
     controller.focus();
     return controller;
   }

--- a/public/posts/learning-go-building-a-mud/index.html
+++ b/public/posts/learning-go-building-a-mud/index.html
@@ -220,6 +220,7 @@ Aug 10, 2025
   var src = document.currentScript && document.currentScript.getAttribute('data-mud-src') || "\/js\/mud-overlay.js";
   var pendingUrl = null;
   var pendingAnchor = null;
+  var pendingForce = false;
   var loading = false;
 
   var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
@@ -247,20 +248,32 @@ Aug 10, 2025
     if (!u && p) u = (location.protocol==='https:'?'wss://':'ws://') + location.host + p;
     return u;
   }
-  function summon(url, anchor){
-    if (!url) return;
+  function pathToUrl(path){
+    if (!path) return '';
+    var raw = String(path).trim();
+    if (!raw) return '';
+    if (/^wss?:\/\//i.test(raw)) return raw;
+    if (raw.charAt(0) !== '/') raw = '/' + raw;
+    var scheme = location.protocol === 'https:' ? 'wss://' : 'ws://';
+    return scheme + location.host + raw;
+  }
+  function summon(url, anchor, options){
+    options = options || {};
+    var force = !!options.force;
+    if (!url && !force) return;
     var targetAnchor = anchor && anchor.nodeType === 1 ? anchor : null;
     if (window.spawnMudOverlay) {
-      if (targetAnchor) {
-        window.spawnMudOverlay(url, { anchor: targetAnchor });
-      } else {
-        window.spawnMudOverlay(url);
-      }
+      var spawnOptions = {};
+      if (targetAnchor) spawnOptions.anchor = targetAnchor;
+      if (force && !url) spawnOptions.deferConnect = true;
+      var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+      window.spawnMudOverlay(url || undefined, opts);
       return;
     }
 
     pendingUrl = url;
     pendingAnchor = targetAnchor;
+    pendingForce = force && !url;
     if (loading) return;
 
     loading = true;
@@ -270,12 +283,13 @@ Aug 10, 2025
       loading = false;
       var target = pendingUrl; pendingUrl = null;
       var anchor = pendingAnchor; pendingAnchor = null;
-      if (window.spawnMudOverlay && target) {
-        if (anchor) {
-          window.spawnMudOverlay(target, { anchor: anchor });
-        } else {
-          window.spawnMudOverlay(target);
-        }
+      var forceLaunch = pendingForce; pendingForce = false;
+      if (window.spawnMudOverlay) {
+        var spawnOptions = {};
+        if (anchor) spawnOptions.anchor = anchor;
+        if (forceLaunch && !target) spawnOptions.deferConnect = true;
+        var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+        window.spawnMudOverlay(target || undefined, opts);
       }
     };
     s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
@@ -291,15 +305,23 @@ Aug 10, 2025
 
   var autoLaunch = false;
   var explicitUrl = null;
+  var explicitPath = null;
 
   if (autoLaunch) {
     var link = findFirstLink();
-    var targetUrl = explicitUrl || resolveUrl(link) || null;
+    var targetUrl = explicitUrl || resolveUrl(link) || pathToUrl(explicitPath) || null;
+    var summonOptions = targetUrl ? null : { force: true };
     if (targetUrl) {
       if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });
       } else {
         summon(targetUrl, link);
+      }
+    } else if (summonOptions) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function(){ summon(null, link, summonOptions); }, { once: true });
+      } else {
+        summon(null, link, summonOptions);
       }
     }
   }

--- a/public/projects/dmud/index.html
+++ b/public/projects/dmud/index.html
@@ -200,7 +200,7 @@
 <h1>DMUD</h1>
 <br/>
 # Getting Started
-<p>To clear the MUD console type &ldquo;/clear&rdquo; for in-game help type &ldquo;help&rdquo; &ndash; to join click π</p>
+<p>The console should pop open automatically. To clear the MUD console type &ldquo;/clear&rdquo;; for in-game help type &ldquo;help&rdquo;. If it doesn&rsquo;t launch on its own, click <a data-mud-path="/mud" href="#join-dmud" aria-label="Launch the DMUD console">π</a>.</p>
 </div>
     
 <script data-mud-src="/js/mud-overlay.js">
@@ -209,6 +209,7 @@
   var src = document.currentScript && document.currentScript.getAttribute('data-mud-src') || "\/js\/mud-overlay.js";
   var pendingUrl = null;
   var pendingAnchor = null;
+  var pendingForce = false;
   var loading = false;
 
   var TRIGGER_SELECTOR = 'a[data-mud],a[data-mud-ws],a[href^="ws"],a[href^="wss"],[data-mud-mount]';
@@ -235,20 +236,32 @@
     if (!u && p) u = (location.protocol==='https:'?'wss://':'ws://') + location.host + p;
     return u;
   }
-  function summon(url, anchor){
-    if (!url) return;
+  function pathToUrl(path){
+    if (!path) return '';
+    var raw = String(path).trim();
+    if (!raw) return '';
+    if (/^wss?:\/\//i.test(raw)) return raw;
+    if (raw.charAt(0) !== '/') raw = '/' + raw;
+    var scheme = location.protocol === 'https:' ? 'wss://' : 'ws://';
+    return scheme + location.host + raw;
+  }
+  function summon(url, anchor, options){
+    options = options || {};
+    var force = !!options.force;
+    if (!url && !force) return;
     var targetAnchor = anchor && anchor.nodeType === 1 ? anchor : null;
     if (window.spawnMudOverlay) {
-      if (targetAnchor) {
-        window.spawnMudOverlay(url, { anchor: targetAnchor });
-      } else {
-        window.spawnMudOverlay(url);
-      }
+      var spawnOptions = {};
+      if (targetAnchor) spawnOptions.anchor = targetAnchor;
+      if (force && !url) spawnOptions.deferConnect = true;
+      var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+      window.spawnMudOverlay(url || undefined, opts);
       return;
     }
 
     pendingUrl = url;
     pendingAnchor = targetAnchor;
+    pendingForce = force && !url;
     if (loading) return;
 
     loading = true;
@@ -258,12 +271,13 @@
       loading = false;
       var target = pendingUrl; pendingUrl = null;
       var anchor = pendingAnchor; pendingAnchor = null;
-      if (window.spawnMudOverlay && target) {
-        if (anchor) {
-          window.spawnMudOverlay(target, { anchor: anchor });
-        } else {
-          window.spawnMudOverlay(target);
-        }
+      var forceLaunch = pendingForce; pendingForce = false;
+      if (window.spawnMudOverlay) {
+        var spawnOptions = {};
+        if (anchor) spawnOptions.anchor = anchor;
+        if (forceLaunch && !target) spawnOptions.deferConnect = true;
+        var opts = Object.keys(spawnOptions).length ? spawnOptions : undefined;
+        window.spawnMudOverlay(target || undefined, opts);
       }
     };
     s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
@@ -279,15 +293,23 @@
 
   var autoLaunch = true;
   var explicitUrl = null;
+  var explicitPath = "/mud";
 
   if (autoLaunch) {
     var link = findFirstLink();
-    var targetUrl = explicitUrl || resolveUrl(link) || null;
+    var targetUrl = explicitUrl || resolveUrl(link) || pathToUrl(explicitPath) || null;
+    var summonOptions = targetUrl ? null : { force: true };
     if (targetUrl) {
       if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function(){ summon(targetUrl, link); }, { once: true });
       } else {
         summon(targetUrl, link);
+      }
+    } else if (summonOptions) {
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', function(){ summon(null, link, summonOptions); }, { once: true });
+      } else {
+        summon(null, link, summonOptions);
       }
     }
   }

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -724,6 +724,7 @@
   // ---------- public API ----------
   function spawn(initialUrl, options) {
     const anchor = options && options.anchor && options.anchor.nodeType === 1 ? options.anchor : lastAnchor;
+    const deferConnect = !!(options && options.deferConnect);
     // build or reuse
     if (!controller || !document.body.contains(controller.root)) {
       controller = buildOverlay(anchor);
@@ -737,7 +738,9 @@
     controller.root.style.zIndex = String(baseZ + 1);
 
     if (initialUrl) controller.setUrl(initialUrl);
-    controller.connect();
+    if (!deferConnect) {
+      controller.connect();
+    }
     controller.focus();
     return controller;
   }


### PR DESCRIPTION
## Summary
- allow the lazy-loaded MUD overlay to spawn even without a data-mud trigger by falling back to a configured path or forcing the overlay open
- add the DMUD project path metadata and refresh the page copy with a manual fallback link
- sync the compiled static assets with the updated overlay loader and content

## Testing
- `hugo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d0f84a4f088320911a9e5a43043246