### PR TITLE
Use absolute DMUD websocket and relative site links

### DIFF
--- a/layouts/partials/mud-overlay.html
+++ b/layouts/partials/mud-overlay.html
@@ -90,8 +90,8 @@
   }, { capture: true });
 
   var autoLaunch = {{ if or .Params.mud_autostart .Site.Params.mud_autostart }}true{{ else }}false{{ end }};
-  var explicitUrl = {{ with or .Params.mud_ws .Site.Params.mud_ws }}{{ printf "%q" . }}{{ else }}null{{ end }};
-  var explicitPath = {{ with or .Params.mud_path .Site.Params.mud_path }}{{ printf "%q" . }}{{ else }}null{{ end }};
+  var explicitUrl = {{ with or .Params.mud_ws .Site.Params.mud_ws }}{{ printf "%q" . | safeJS }}{{ else }}null{{ end }};
+  var explicitPath = {{ with or .Params.mud_path .Site.Params.mud_path }}{{ printf "%q" . | safeJS }}{{ else }}null{{ end }};
 
   if (autoLaunch) {
     var link = findFirstLink();

--- a/public/404.html
+++ b/public/404.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/404.html</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -48,7 +48,7 @@
        <meta property="og:title" content="404 Page not found" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/404.html" />
+<meta property="og:url" content="https://dusty.wtf/404.html" />
 
 
 <meta name="twitter:title" content="404 Page not found"/>
@@ -61,10 +61,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/404.html'
+              href='/404.html'
               >404.html</a
             >/
           </div>
@@ -73,17 +73,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -194,7 +194,7 @@
     </div>
     <div class="container animate-fade-up">
 <h1>Page not found</h1>
-<p><a href="http://localhost:1313/">Return to the home page</a>.</p>
+<p><a href="/">Return to the home page</a>.</p>
 </div>
     
 

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/about/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -48,16 +48,16 @@
        <meta property="og:title" content="About" />
 <meta property="og:description" content="be kind, please rewind" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="http://localhost:1313/about/" /><meta property="article:published_time" content="2016-11-05T21:05:33+05:30" />
+<meta property="og:url" content="https://dusty.wtf/about/" /><meta property="article:published_time" content="2016-11-05T21:05:33+05:30" />
 
 
 
 <meta name="twitter:title" content="About"/>
-<meta name="twitter:description" content="
-  
-
-  
-  Yoooo, I&rsquo;m Dusty✌️"/>
+<meta name="twitter:description" content="Yoooo, I&rsquo;m Dusty✌️
+I love taking pictures shit-posting traveling and making things
+Currently in gradschool working on my master&rsquo;s degree in Computer Science and spending that entire time pretending im not voluntarily learning stuff
+Have been a software engineer for just over two decades, but honestly at this point I figure we should all packup and move to the forest &ndash; we&rsquo;d be better off
+Anyway, nice to meet you!"/>
 
 </head>
   <body class="terminal">
@@ -66,10 +66,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/about'
+              href='/about'
               >about</a
             >/
           </div>
@@ -78,17 +78,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -199,16 +199,16 @@
     </div>
     <div class="container animate-fade-up">
 <h1>About</h1>
-<div id="pr-1758530200061257000" class="profile-row" style="--img-size: 250px">
+<div id="pr-1758531477668826634" class="profile-row" style="--img-size: 250px">
   <style>
      
-    #pr-1758530200061257000.profile-row {
+    #pr-1758531477668826634.profile-row {
       display: flex;
       align-items: flex-start;
       gap: 1rem;
       margin: 1rem 0;
     }
-    #pr-1758530200061257000 .profile-row__img {
+    #pr-1758531477668826634 .profile-row__img {
       flex: 0 0 var(--img-size);
       width: var(--img-size);
       height: var(--img-size);
@@ -216,19 +216,19 @@
       border-radius: 50%;
       display: block;
     }
-    #pr-1758530200061257000 .profile-row__text {
+    #pr-1758531477668826634 .profile-row__text {
       flex: 1 1 0;
       min-width: 12rem;
 
     }
      
-    #pr-1758530200061257000 .profile-row__text p {
+    #pr-1758531477668826634 .profile-row__text p {
       margin: 0 0 0.75rem 0;
       text-align: left;
     }
     @media (max-width: 600px) {
-      #pr-1758530200061257000.profile-row { flex-direction: column; align-items: center; }
-      #pr-1758530200061257000 .profile-row__text { width: 100%; }
+      #pr-1758531477668826634.profile-row { flex-direction: column; align-items: center; }
+      #pr-1758531477668826634 .profile-row__text { width: 100%; }
     }
   </style>
 

--- a/public/categories/index.html
+++ b/public/categories/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/categories/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -46,11 +46,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
         
-    <link href="http://localhost:1313/categories/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
+    <link href="/categories/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
      <meta property="og:title" content="Categories" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/categories/" />
+<meta property="og:url" content="https://dusty.wtf/categories/" />
 
 
 <meta name="twitter:title" content="Categories"/>
@@ -63,10 +63,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/categories'
+              href='/categories'
               >categories</a
             >/
           </div>
@@ -75,17 +75,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             

--- a/public/categories/index.xml
+++ b/public/categories/index.xml
@@ -2,10 +2,10 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Categories on dusty.wtf</title>
-    <link>http://localhost:1313/categories/</link>
+    <link>https://dusty.wtf/categories/</link>
     <description>Recent content in Categories on dusty.wtf</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <atom:link href="http://localhost:1313/categories/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://dusty.wtf/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/public/index.html
+++ b/public/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en-us">
   <head>
-	<meta name="generator" content="Hugo 0.150.0"><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+	<meta name="generator" content="Hugo 0.123.7">
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/</title>
@@ -38,8 +38,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -47,11 +47,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
         
-    <link href="http://localhost:1313/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
+    <link href="/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
      <meta property="og:title" content="dusty.wtf" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/" />
+<meta property="og:url" content="https://dusty.wtf/" />
 
 
 <meta name="twitter:title" content="dusty.wtf"/>
@@ -64,7 +64,7 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# 
           </div>
@@ -73,17 +73,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -201,7 +201,7 @@
   <div class="intro">
     <div class="description">
       Good-trouble maker, taco enthusiast, principle engineer, maker, elder millennial, he/him/y'all
-      <a href="about/">(more)</a>
+      <a href="/about/">(more)</a>
     </div>
     <ul class="social-links">
   
@@ -253,7 +253,7 @@
         <div class="post">
             <p>
                 <div class="date">Aug 29, 2025</div>
-                <h1><a href="http://localhost:1313/posts/amsat-adventures-pt1/" title="AMSAT Adventures (Part 1)">AMSAT Adventures (Part 1)</a></h1>
+                <h1><a href="/posts/amsat-adventures-pt1/" title="AMSAT Adventures (Part 1)">AMSAT Adventures (Part 1)</a></h1>
                 <p>Wouldn&rsquo;t it be awesome to pull telemetery and images from the downlink of a satellite orbiting the Earth?</p>
             </p>
         </div>    
@@ -264,9 +264,9 @@
 <h1>Blogrolls & Webrings</h1>
 <p><a href="https://chadxz.dev/" target="_blank">chad</a> - <a href="https://blog.rldn.net/" target="_blank">mog</a> - <a href="https://frcv.net" target="_blank">nathan</a> - <a href="https://steveklabnik.com/writing/" target="_blank">steve klabnik</a></p>
 <p>
-  <a href="https://dusty.wtf" style="display:inline-block;">
+  <a href="/" style="display:inline-block;">
     <img
-      src="dustybutton.gif"
+      src="/dustybutton.gif"
       alt="dusty"
       width="88"
       height="31"
@@ -286,7 +286,7 @@
 <p>
   <a href="https://cyber.dabamos.de/88x31/index.html" target="_blank" style="display:inline-block; margin-right: 10px">
     <img
-      src="a1animate3.gif"
+      src="/a1animate3.gif"
       alt="clipart"
       width="88"
       height="31"
@@ -294,35 +294,35 @@
       >
   </a>
   <img
-    src="anybrow.gif"
+    src="/anybrow.gif"
     alt="dusty"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="aol_sucks02.gif"
+    src="/aol_sucks02.gif"
     alt="aolsucks"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="apple.gif"
+    src="/apple.gif"
     alt="apple"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="say-no-to-web3.gif"
+    src="/say-no-to-web3.gif"
     alt="no-web-3-keep-the-web-open"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="acab.gif"
+    src="/acab.gif"
     alt="acab"
     width="88"
     height="31"

--- a/public/index.xml
+++ b/public/index.xml
@@ -2,39 +2,39 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>dusty.wtf</title>
-    <link>http://localhost:1313/</link>
+    <link>https://dusty.wtf/</link>
     <description>Recent content on dusty.wtf</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 29 Aug 2025 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://dusty.wtf/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>AMSAT Adventures (Part 1)</title>
-      <link>http://localhost:1313/posts/amsat-adventures-pt1/</link>
+      <link>https://dusty.wtf/posts/amsat-adventures-pt1/</link>
       <pubDate>Fri, 29 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/posts/amsat-adventures-pt1/</guid>
+      <guid>https://dusty.wtf/posts/amsat-adventures-pt1/</guid>
       <description>&lt;p&gt;Wouldn&amp;rsquo;t it be awesome to pull telemetery and images from the downlink of a satellite orbiting the Earth?&lt;/p&gt;</description>
     </item>
     <item>
       <title>DMUD</title>
-      <link>http://localhost:1313/projects/dmud/</link>
+      <link>https://dusty.wtf/projects/dmud/</link>
       <pubDate>Sun, 10 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/projects/dmud/</guid>
+      <guid>https://dusty.wtf/projects/dmud/</guid>
       <description></description>
     </item>
     <item>
       <title>Vibe-coding a MUD w/ Robots: ChatGPT, Claude, &amp; Codex agents</title>
-      <link>http://localhost:1313/posts/learning-go-building-a-mud/</link>
+      <link>https://dusty.wtf/posts/learning-go-building-a-mud/</link>
       <pubDate>Sun, 10 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/posts/learning-go-building-a-mud/</guid>
-      <description>&lt;p&gt;Placeholder for future talk?&lt;/p&gt;&#xA;&lt;!--more--!&gt;&#xA;&#xA;# DMUD&#xA;&#xA;..</description>
+      <guid>https://dusty.wtf/posts/learning-go-building-a-mud/</guid>
+      <description>Placeholder for future talk?</description>
     </item>
     <item>
       <title>About</title>
-      <link>http://localhost:1313/about/</link>
+      <link>https://dusty.wtf/about/</link>
       <pubDate>Sat, 05 Nov 2016 21:05:33 +0530</pubDate>
-      <guid>http://localhost:1313/about/</guid>
-      <description>&lt;div id=&#34;pr-1758530200061257000&#34; class=&#34;profile-row&#34; style=&#34;--img-size: 250px&#34;&gt;&#xA;  &lt;style&gt;&#xA;     &#xA;    #pr-1758530200061257000.profile-row {&#xA;      display: flex;&#xA;      align-items: flex-start;&#xA;      gap: 1rem;&#xA;      margin: 1rem 0;&#xA;    }&#xA;    #pr-1758530200061257000 .profile-row__img {&#xA;      flex: 0 0 var(--img-size);&#xA;      width: var(--img-size);&#xA;      height: var(--img-size);&#xA;      object-fit: cover;&#xA;      border-radius: 50%;&#xA;      display: block;&#xA;    }&#xA;    #pr-1758530200061257000 .profile-row__text {&#xA;      flex: 1 1 0;&#xA;      min-width: 12rem;&#xA;&#xA;    }&#xA;     &#xA;    #pr-1758530200061257000 .profile-row__text p {&#xA;      margin: 0 0 0.75rem 0;&#xA;      text-align: left;&#xA;    }&#xA;    @media (max-width: 600px) {&#xA;      #pr-1758530200061257000.profile-row { flex-direction: column; align-items: center; }&#xA;      #pr-1758530200061257000 .profile-row__text { width: 100%; }&#xA;    }&#xA;  &lt;/style&gt;&#xA;&#xA;  &lt;img&#xA;    class=&#34;profile-row__img&#34;&#xA;    src=&#34;http://localhost:1313/df.jpg&#34;&#xA;    alt=&#34;Dusty&#34;&#xA;    width=&#34;250&#34;&#xA;    height=&#34;250&#34;&#xA;    loading=&#34;lazy&#34;&#xA;    decoding=&#34;async&#34;&#xA;  /&gt;&#xA;  &lt;div class=&#34;profile-row__text&#34;&gt;&lt;p&gt;Yoooo, I&amp;rsquo;m Dusty✌️&lt;/p&gt;</description>
+      <guid>https://dusty.wtf/about/</guid>
+      <description>Yoooo, I&amp;rsquo;m Dusty✌️&#xA;I love taking pictures shit-posting traveling and making things&#xA;Currently in gradschool working on my master&amp;rsquo;s degree in Computer Science and spending that entire time pretending im not voluntarily learning stuff&#xA;Have been a software engineer for just over two decades, but honestly at this point I figure we should all packup and move to the forest &amp;ndash; we&amp;rsquo;d be better off&#xA;Anyway, nice to meet you!</description>
     </item>
   </channel>
 </rss>

--- a/public/posts/amsat-adventures-pt1/index.html
+++ b/public/posts/amsat-adventures-pt1/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/posts/amsat-adventures-pt1/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -48,7 +48,7 @@
        <meta property="og:title" content="AMSAT Adventures (Part 1)" />
 <meta property="og:description" content="be kind, please rewind" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="http://localhost:1313/posts/amsat-adventures-pt1/" /><meta property="article:published_time" content="2025-08-29T00:00:00+00:00" />
+<meta property="og:url" content="https://dusty.wtf/posts/amsat-adventures-pt1/" /><meta property="article:published_time" content="2025-08-29T00:00:00+00:00" />
 
 
 
@@ -62,13 +62,13 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/posts'
+              href='/posts'
               >posts</a
             >/<a
-              href='http://localhost:1313/posts/amsat-adventures-pt1'
+              href='/posts/amsat-adventures-pt1'
               >amsat-adventures-pt1</a
             >/
           </div>
@@ -77,17 +77,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             

--- a/public/posts/index.html
+++ b/public/posts/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/posts/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -46,11 +46,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
         
-    <link href="http://localhost:1313/posts/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
+    <link href="/posts/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
      <meta property="og:title" content="Posts" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/posts/" />
+<meta property="og:url" content="https://dusty.wtf/posts/" />
 
 
 <meta name="twitter:title" content="Posts"/>
@@ -63,10 +63,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/posts'
+              href='/posts'
               >posts</a
             >/
           </div>
@@ -75,17 +75,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -205,7 +205,7 @@
         <div class="post">
             <p>
                 <div class="date">Aug. 29, 2025</div>    
-                <h1><a href="http://localhost:1313/posts/amsat-adventures-pt1/" title="AMSAT Adventures (Part 1)">AMSAT Adventures (Part 1)</a></h1>
+                <h1><a href="/posts/amsat-adventures-pt1/" title="AMSAT Adventures (Part 1)">AMSAT Adventures (Part 1)</a></h1>
                 <p>Wouldn&rsquo;t it be awesome to pull telemetery and images from the downlink of a satellite orbiting the Earth?</p>
             </p>
         </div>

--- a/public/posts/index.xml
+++ b/public/posts/index.xml
@@ -2,25 +2,25 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Posts on dusty.wtf</title>
-    <link>http://localhost:1313/posts/</link>
+    <link>https://dusty.wtf/posts/</link>
     <description>Recent content in Posts on dusty.wtf</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Fri, 29 Aug 2025 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/posts/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://dusty.wtf/posts/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>AMSAT Adventures (Part 1)</title>
-      <link>http://localhost:1313/posts/amsat-adventures-pt1/</link>
+      <link>https://dusty.wtf/posts/amsat-adventures-pt1/</link>
       <pubDate>Fri, 29 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/posts/amsat-adventures-pt1/</guid>
+      <guid>https://dusty.wtf/posts/amsat-adventures-pt1/</guid>
       <description>&lt;p&gt;Wouldn&amp;rsquo;t it be awesome to pull telemetery and images from the downlink of a satellite orbiting the Earth?&lt;/p&gt;</description>
     </item>
     <item>
       <title>Vibe-coding a MUD w/ Robots: ChatGPT, Claude, &amp; Codex agents</title>
-      <link>http://localhost:1313/posts/learning-go-building-a-mud/</link>
+      <link>https://dusty.wtf/posts/learning-go-building-a-mud/</link>
       <pubDate>Sun, 10 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/posts/learning-go-building-a-mud/</guid>
-      <description>&lt;p&gt;Placeholder for future talk?&lt;/p&gt;&#xA;&lt;!--more--!&gt;&#xA;&#xA;# DMUD&#xA;&#xA;..</description>
+      <guid>https://dusty.wtf/posts/learning-go-building-a-mud/</guid>
+      <description>Placeholder for future talk?</description>
     </item>
   </channel>
 </rss>

--- a/public/posts/learning-go-building-a-mud/index.html
+++ b/public/posts/learning-go-building-a-mud/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/posts/learning-go-building-a-mud/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -48,13 +48,12 @@
        <meta property="og:title" content="Vibe-coding a MUD w/ Robots: ChatGPT, Claude, &amp; Codex agents" />
 <meta property="og:description" content="be kind, please rewind" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="http://localhost:1313/posts/learning-go-building-a-mud/" /><meta property="article:published_time" content="2025-08-10T00:00:00+00:00" />
+<meta property="og:url" content="https://dusty.wtf/posts/learning-go-building-a-mud/" /><meta property="article:published_time" content="2025-08-10T00:00:00+00:00" />
 
 
 
 <meta name="twitter:title" content="Vibe-coding a MUD w/ Robots: ChatGPT, Claude, &amp; Codex agents"/>
-<meta name="twitter:description" content="Placeholder for future talk?
-"/>
+<meta name="twitter:description" content="Placeholder for future talk?"/>
 
 </head>
   <body class="terminal">
@@ -63,13 +62,13 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/posts'
+              href='/posts'
               >posts</a
             >/<a
-              href='http://localhost:1313/posts/learning-go-building-a-mud'
+              href='/posts/learning-go-building-a-mud'
               >learning-go-building-a-mud</a
             >/
           </div>
@@ -78,17 +77,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             

--- a/public/projects/dmud/index.html
+++ b/public/projects/dmud/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/projects/dmud/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -48,7 +48,7 @@
        <meta property="og:title" content="DMUD" />
 <meta property="og:description" content="be kind, please rewind" />
 <meta property="og:type" content="article" />
-<meta property="og:url" content="http://localhost:1313/projects/dmud/" /><meta property="article:published_time" content="2025-08-10T00:00:00+00:00" />
+<meta property="og:url" content="https://dusty.wtf/projects/dmud/" /><meta property="article:published_time" content="2025-08-10T00:00:00+00:00" />
 
 
 
@@ -62,13 +62,13 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/projects'
+              href='/projects'
               >projects</a
             >/<a
-              href='http://localhost:1313/projects/dmud'
+              href='/projects/dmud'
               >dmud</a
             >/
           </div>
@@ -77,17 +77,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -293,7 +293,7 @@
   }, { capture: true });
 
   var autoLaunch = true;
-  var explicitUrl = "\"wss://dmud-495017347762.us-central1.run.app/ws\"";
+  var explicitUrl = "wss://dmud-495017347762.us-central1.run.app/ws";
   var explicitPath = null;
 
   if (autoLaunch) {

--- a/public/projects/index.html
+++ b/public/projects/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/projects/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -46,11 +46,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
         
-    <link href="http://localhost:1313/projects/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
+    <link href="/projects/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
      <meta property="og:title" content="Projects" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/projects/" />
+<meta property="og:url" content="https://dusty.wtf/projects/" />
 
 
 <meta name="twitter:title" content="Projects"/>
@@ -63,10 +63,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/projects'
+              href='/projects'
               >projects</a
             >/
           </div>
@@ -75,17 +75,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             
@@ -205,7 +205,7 @@
         <div class="post">
             <p>
                 <div class="date">Aug. 10, 2025</div>    
-                <h1><a href="http://localhost:1313/projects/dmud/" title="DMUD">DMUD</a></h1>
+                <h1><a href="/projects/dmud/" title="DMUD">DMUD</a></h1>
                 
             </p>
         </div>

--- a/public/projects/index.xml
+++ b/public/projects/index.xml
@@ -2,17 +2,17 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Projects on dusty.wtf</title>
-    <link>http://localhost:1313/projects/</link>
+    <link>https://dusty.wtf/projects/</link>
     <description>Recent content in Projects on dusty.wtf</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
     <lastBuildDate>Sun, 10 Aug 2025 00:00:00 +0000</lastBuildDate>
-    <atom:link href="http://localhost:1313/projects/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://dusty.wtf/projects/index.xml" rel="self" type="application/rss+xml" />
     <item>
       <title>DMUD</title>
-      <link>http://localhost:1313/projects/dmud/</link>
+      <link>https://dusty.wtf/projects/dmud/</link>
       <pubDate>Sun, 10 Aug 2025 00:00:00 +0000</pubDate>
-      <guid>http://localhost:1313/projects/dmud/</guid>
+      <guid>https://dusty.wtf/projects/dmud/</guid>
       <description></description>
     </item>
   </channel>

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -4,35 +4,35 @@
     
         
         <url>
-            <loc>http://localhost:1313/posts/amsat-adventures-pt1/</loc>
+            <loc>https://dusty.wtf/posts/amsat-adventures-pt1/</loc>
             <lastmod>2025-08-29T00:00:00+00:00</lastmod>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/</loc>
+            <loc>https://dusty.wtf/</loc>
             <lastmod>2025-08-29T00:00:00+00:00</lastmod>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/posts/</loc>
+            <loc>https://dusty.wtf/posts/</loc>
             <lastmod>2025-08-29T00:00:00+00:00</lastmod>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/projects/dmud/</loc>
+            <loc>https://dusty.wtf/projects/dmud/</loc>
             <lastmod>2025-08-10T00:00:00+00:00</lastmod>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/projects/</loc>
+            <loc>https://dusty.wtf/projects/</loc>
             <lastmod>2025-08-10T00:00:00+00:00</lastmod>
         </url>
         
@@ -41,20 +41,20 @@
     
         
         <url>
-            <loc>http://localhost:1313/about/</loc>
+            <loc>https://dusty.wtf/about/</loc>
             <lastmod>2016-11-05T21:05:33+05:30</lastmod>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/categories/</loc>
+            <loc>https://dusty.wtf/categories/</loc>
         </url>
         
     
         
         <url>
-            <loc>http://localhost:1313/tags/</loc>
+            <loc>https://dusty.wtf/tags/</loc>
         </url>
         
     

--- a/public/tags/index.html
+++ b/public/tags/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html lang="en-us">
-  <head><script src="/livereload.js?mindelay=10&amp;v=2&amp;port=1313&amp;path=livereload" data-no-instant defer></script>
+  <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>dusty.wtf/tags/</title>
@@ -37,8 +37,8 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
-    href="http://localhost:1313/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="http://localhost:1313/hugo-theme-console/css/console.css">
+    <link rel="stylesheet" href="/hugo-theme-console/css/terminal-0.7.4.min.css"> <link rel="stylesheet"
+    href="/hugo-theme-console/css/animate-4.1.1.min.css"> <link rel="stylesheet" href="/hugo-theme-console/css/console.css">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     
     <!--[if lt IE 9]>
@@ -46,11 +46,11 @@
       <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
     <![endif]-->
         
-    <link href="http://localhost:1313/tags/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
+    <link href="/tags/index.xml" rel="alternate" type="application/rss+xml" title="dusty.wtf" />
      <meta property="og:title" content="Tags" />
 <meta property="og:description" content="" />
 <meta property="og:type" content="website" />
-<meta property="og:url" content="http://localhost:1313/tags/" />
+<meta property="og:url" content="https://dusty.wtf/tags/" />
 
 
 <meta name="twitter:title" content="Tags"/>
@@ -63,10 +63,10 @@
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
              
-            <a href="http://localhost:1313/" class="no-style "
+            <a href="/" class="no-style "
               >dusty.wtf</a
             >:~# <a
-              href='http://localhost:1313/tags'
+              href='/tags'
               >tags</a
             >/
           </div>
@@ -75,17 +75,17 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/about/"> <span property="name">about</span></a>
+              <a property="item" typeof="WebPage" href="/about/"> <span property="name">about</span></a>
               <meta property="position" content="1" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/posts/"> <span property="name">posts</span></a>
+              <a property="item" typeof="WebPage" href="/posts/"> <span property="name">posts</span></a>
               <meta property="position" content="2" />
             </li>
             
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="http://localhost:1313/projects/"> <span property="name">projects</span></a>
+              <a property="item" typeof="WebPage" href="/projects/"> <span property="name">projects</span></a>
               <meta property="position" content="3" />
             </li>
             

--- a/public/tags/index.xml
+++ b/public/tags/index.xml
@@ -2,10 +2,10 @@
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on dusty.wtf</title>
-    <link>http://localhost:1313/tags/</link>
+    <link>https://dusty.wtf/tags/</link>
     <description>Recent content in Tags on dusty.wtf</description>
-    <generator>Hugo</generator>
+    <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <atom:link href="http://localhost:1313/tags/index.xml" rel="self" type="application/rss+xml" />
+    <atom:link href="https://dusty.wtf/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/themes/hugo-theme-console/layouts/404.html
+++ b/themes/hugo-theme-console/layouts/404.html
@@ -1,4 +1,4 @@
 {{ define "main" }}
 <h1>Page not found</h1>
-<p><a href="{{ .Site.BaseURL }}">Return to the home page</a>.</p>
+<p><a href="{{ "/" | relURL }}">Return to the home page</a>.</p>
 {{ end }}

--- a/themes/hugo-theme-console/layouts/_default/baseof.html
+++ b/themes/hugo-theme-console/layouts/_default/baseof.html
@@ -37,9 +37,9 @@
       })();
     </script>
     <script defer data-domain="dusty.wtf" src="https://plausible.io/js/script.outbound-links.js"></script>
-    <link rel="stylesheet" href="{{ "hugo-theme-console/css/terminal-0.7.4.min.css" | absURL }}"> <link rel="stylesheet"
-    href="{{ "hugo-theme-console/css/animate-4.1.1.min.css" | absURL }}"> <link rel="stylesheet" href="{{
-    "hugo-theme-console/css/console.css" | absURL }}">
+    <link rel="stylesheet" href="{{ "hugo-theme-console/css/terminal-0.7.4.min.css" | relURL }}"> <link rel="stylesheet"
+    href="{{ "hugo-theme-console/css/animate-4.1.1.min.css" | relURL }}"> <link rel="stylesheet" href="{{
+    "hugo-theme-console/css/console.css" | relURL }}">
     <script src="https://kit.fontawesome.com/386d44956a.js" crossorigin="anonymous"></script>
     {{ `
     <!--[if lt IE 9]>
@@ -48,7 +48,7 @@
     <![endif]-->
     ` | safeHTML }} {{- partial "favicon.html" . -}} {{ with .OutputFormats.Get "RSS" }} {{ printf `
     <link href="%s" rel="%s" type="%s" title="%s" />
-    ` .Permalink .Rel .MediaType.Type $.Site.Title | safeHTML }} {{ end }} {{- partial "opengraph.html" . -}} {{- partial
+    ` .RelPermalink .Rel .MediaType.Type $.Site.Title | safeHTML }} {{ end }} {{- partial "opengraph.html" . -}} {{- partial
     "twitter_cards.html" . -}} {{ template "_internal/google_analytics.html" . }} {{- partial "header.html" . -}}
   </head>
   <body class="terminal">
@@ -56,11 +56,11 @@
       <div class="terminal-nav">
         <header class="terminal-logo">
           <div class="logo terminal-prompt">
-            {{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }} {{ $.Scratch.Add "path" .Site.BaseURL }}
-            <a href="{{ .Site.BaseURL }}" class="no-style {{ with .Site.Params.TitleCutting }}site-name{{ end }}"
+            {{ $url := trim .RelPermalink "/" }} {{ $.Scratch.Set "path" "/" }}
+            <a href="{{ "/" | relURL }}" class="no-style {{ with .Site.Params.TitleCutting }}site-name{{ end }}"
               >{{ .Site.Title }}</a
             >:~# {{ range $index, $element := split $url "/" }}{{ $.Scratch.Add "path" $element }}{{ if ne $element "" }}<a
-              href='{{ $.Scratch.Get "path" | absURL }}'
+              href='{{ $.Scratch.Get "path" | relURL }}'
               >{{ . }}</a
             >/{{ $.Scratch.Add "path" "/" }}{{ end }}{{ end }}
           </div>
@@ -69,7 +69,7 @@
           <ul vocab="https://schema.org/" typeof="BreadcrumbList">
             {{ range $index, $element := .Site.Params.navlinks }}
             <li property="itemListElement" typeof="ListItem">
-              <a property="item" typeof="WebPage" href="{{ absURL .url }}"> <span property="name">{{ .name }}</span></a>
+              <a property="item" typeof="WebPage" href="{{ .url | relURL }}"> <span property="name">{{ .name }}</span></a>
               <meta property="position" content="{{ add $index 1}}" />
             </li>
             {{ end }}

--- a/themes/hugo-theme-console/layouts/_default/list.html
+++ b/themes/hugo-theme-console/layouts/_default/list.html
@@ -9,7 +9,7 @@
         <div class="post">
             <p>
                 <div class="date">{{ .PublishDate.Format "Jan. 2, 2006" }}</div>    
-                <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
+                <h1><a href="{{ .RelPermalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
                 {{ .Summary }}
             </p>
         </div>

--- a/themes/hugo-theme-console/layouts/gallery/list.html
+++ b/themes/hugo-theme-console/layouts/gallery/list.html
@@ -4,7 +4,7 @@
 <div class="image-grid">
     {{ range sort .Pages "Date" "desc" }}
         {{ if and (isset .Params "image") .Params.image }}
-            <a href="{{ .Permalink }}" title="{{ .Title }}">
+            <a href="{{ .RelPermalink }}" title="{{ .Title }}">
             {{ $image := .Page.Resources.GetMatch .Params.image }}
             {{ with $image }}
                 {{ $thumb := .Resize "400x" }}

--- a/themes/hugo-theme-console/layouts/index.html
+++ b/themes/hugo-theme-console/layouts/index.html
@@ -7,7 +7,7 @@
   <div class="intro">
     <div class="description">
       Good-trouble maker, taco enthusiast, principle engineer, maker, elder millennial, he/him/y'all
-      <a href="about/">(more)</a>
+      <a href="{{ "about/" | relURL }}">(more)</a>
     </div>
     {{ partial "social.html" . }}
   </div>
@@ -20,7 +20,7 @@
         <div class="post">
             <p>
                 <div class="date">{{ .Date | time.Format ":date_medium" }}</div>
-                <h1><a href="{{ .Permalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
+                <h1><a href="{{ .RelPermalink }}" title="{{ .Title }}">{{ .Title }}</a></h1>
                 {{ .Summary }}
             </p>
         </div>    
@@ -31,9 +31,9 @@
 <h1>Blogrolls & Webrings</h1>
 <p><a href="https://chadxz.dev/" target="_blank">chad</a> - <a href="https://blog.rldn.net/" target="_blank">mog</a> - <a href="https://frcv.net" target="_blank">nathan</a> - <a href="https://steveklabnik.com/writing/" target="_blank">steve klabnik</a></p>
 <p>
-  <a href="https://dusty.wtf" style="display:inline-block;">
+  <a href="{{ "/" | relURL }}" style="display:inline-block;">
     <img
-      src="dustybutton.gif"
+      src="{{ "dustybutton.gif" | relURL }}"
       alt="dusty"
       width="88"
       height="31"
@@ -53,7 +53,7 @@
 <p>
   <a href="https://cyber.dabamos.de/88x31/index.html" target="_blank" style="display:inline-block; margin-right: 10px">
     <img
-      src="a1animate3.gif"
+      src="{{ "a1animate3.gif" | relURL }}"
       alt="clipart"
       width="88"
       height="31"
@@ -61,35 +61,35 @@
       >
   </a>
   <img
-    src="anybrow.gif"
+    src="{{ "anybrow.gif" | relURL }}"
     alt="dusty"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="aol_sucks02.gif"
+    src="{{ "aol_sucks02.gif" | relURL }}"
     alt="aolsucks"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="apple.gif"
+    src="{{ "apple.gif" | relURL }}"
     alt="apple"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="say-no-to-web3.gif"
+    src="{{ "say-no-to-web3.gif" | relURL }}"
     alt="no-web-3-keep-the-web-open"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
   >
   <img
-    src="acab.gif"
+    src="{{ "acab.gif" | relURL }}"
     alt="acab"
     width="88"
     height="31"


### PR DESCRIPTION
## Summary
- set the DMUD project overlay to use the hosted Run.app websocket endpoint rather than a relative path
- update the console theme templates to emit relative URLs for navigation, breadcrumbs, and bundled assets
- regenerate the static site output so the generated HTML reflects the new relative links

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d10c33799083209c00fa7f2354602e