### PR TITLE
Update ACAB badge alt text and add cat cursor

### DIFF
--- a/public/hugo-theme-console/css/console.css
+++ b/public/hugo-theme-console/css/console.css
@@ -611,3 +611,9 @@ mark.hl a,
   color: inherit;
   text-decoration-color: currentColor;
 }
+
+/* Cat cursor for ACAB badge */
+.acab-cat:hover {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23fbcfe8' d='M4 13 L10 4 L12 12 A10 10 0 0 1 20 12 L22 4 L28 13 A12 12 0 1 1 4 13Z'/%3E%3Ccircle cx='12.5' cy='18' r='2.5' fill='%23111114'/%3E%3Ccircle cx='19.5' cy='18' r='2.5' fill='%23111114'/%3E%3Cpath d='M14 24 Q16 26 18 24' stroke='%23111114' stroke-width='2' stroke-linecap='round' fill='none'/%3E%3C/svg%3E") 16 16,
+    pointer;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -323,10 +323,11 @@
   >
   <img
     src="/acab.gif"
-    alt="acab"
+    alt="all cats are beautiful"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
+    class="acab-cat"
   >
 </p>
 

--- a/themes/hugo-theme-console/layouts/index.html
+++ b/themes/hugo-theme-console/layouts/index.html
@@ -90,10 +90,11 @@
   >
   <img
     src="{{ "acab.gif" | relURL }}"
-    alt="acab"
+    alt="all cats are beautiful"
     width="88"
     height="31"
     style="max-width:none;width: 88px;height:auto"
+    class="acab-cat"
   >
 </p>
 

--- a/themes/hugo-theme-console/static/hugo-theme-console/css/console.css
+++ b/themes/hugo-theme-console/static/hugo-theme-console/css/console.css
@@ -611,3 +611,9 @@ mark.hl a,
   color: inherit;
   text-decoration-color: currentColor;
 }
+
+/* Cat cursor for ACAB badge */
+.acab-cat:hover {
+  cursor: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='32' height='32' viewBox='0 0 32 32'%3E%3Cpath fill='%23fbcfe8' d='M4 13 L10 4 L12 12 A10 10 0 0 1 20 12 L22 4 L28 13 A12 12 0 1 1 4 13Z'/%3E%3Ccircle cx='12.5' cy='18' r='2.5' fill='%23111114'/%3E%3Ccircle cx='19.5' cy='18' r='2.5' fill='%23111114'/%3E%3Cpath d='M14 24 Q16 26 18 24' stroke='%23111114' stroke-width='2' stroke-linecap='round' fill='none'/%3E%3C/svg%3E") 16 16,
+    pointer;
+}


### PR DESCRIPTION
## Summary
- update the ACAB badge alt text to read "all cats are beautiful"
- add a hover-only cat cursor for the badge using a small inline SVG data URI

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d1109400708320a7cf0ddfba861316