### PR TITLE
Preserve blank lines in MUD overlay output

### DIFF
--- a/public/js/mud-overlay.js
+++ b/public/js/mud-overlay.js
@@ -566,7 +566,9 @@
       if (grouped && cls === "outl") {
         if (grpCls && grpCls !== cls) flushGroup();
         grpCls = cls;
-        grpBuf += (grpBuf ? "\n" : "") + text;
+        const needsSeparator =
+          grpBuf && !grpBuf.endsWith("\n") && text && !text.startsWith("\n");
+        grpBuf += (needsSeparator ? "\n" : "") + text;
         if (grpTimer) clearTimeout(grpTimer);
         grpTimer = setTimeout(flushGroup, FLUSH_MS);
         return;
@@ -618,8 +620,15 @@
             append("[unknown message type]", "sys");
             return;
           }
-          if (!s || !s.trim()) return; // drop empty/whitespace-only payloads
-          append(s, "outl");
+          if (!s) return;
+          const normalized = s.replace(/\r\n/g, "\n").replace(/\r/g, "");
+          if (!normalized) return;
+          if (!normalized.trim()) {
+            // Preserve intentional blank lines from the server.
+            append(normalized, "outl");
+            return;
+          }
+          append(normalized, "outl");
         } catch (e) {
           append("Message handling error: " + (e?.message || e), "err");
         }
@@ -638,6 +647,8 @@
       });
     };
     const addGap = () => {
+      const last = out.lastElementChild;
+      if (last && last.classList && last.classList.contains("gap")) return;
       out.appendChild(el("div", { class: "gap" }));
       out.scrollTop = out.scrollHeight;
     };
@@ -656,6 +667,8 @@
           : trimmed;
       history.push(trimmed);
       idx = history.length;
+      flushGroup();
+      addGap(); // isolate commands with a leading gap
       append(trimmed, "inl");
       addGap(); // visual gap without a timestamp
       if (!ws || ws.readyState !== WebSocket.OPEN) {

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -566,7 +566,9 @@
       if (grouped && cls === "outl") {
         if (grpCls && grpCls !== cls) flushGroup();
         grpCls = cls;
-        grpBuf += (grpBuf ? "\n" : "") + text;
+        const needsSeparator =
+          grpBuf && !grpBuf.endsWith("\n") && text && !text.startsWith("\n");
+        grpBuf += (needsSeparator ? "\n" : "") + text;
         if (grpTimer) clearTimeout(grpTimer);
         grpTimer = setTimeout(flushGroup, FLUSH_MS);
         return;
@@ -619,10 +621,13 @@
             return;
           }
           if (!s) return;
-          let normalized = s.replace(/\r\n/g, "\n").replace(/\r/g, "");
-          if (/^\n[^\n]/.test(normalized)) normalized = normalized.slice(1);
-          if (/[^\n]\n$/.test(normalized)) normalized = normalized.slice(0, -1);
-          if (!normalized.trim()) return; // drop empty/whitespace-only payloads
+          const normalized = s.replace(/\r\n/g, "\n").replace(/\r/g, "");
+          if (!normalized) return;
+          if (!normalized.trim()) {
+            // Preserve intentional blank lines from the server.
+            append(normalized, "outl");
+            return;
+          }
           append(normalized, "outl");
         } catch (e) {
           append("Message handling error: " + (e?.message || e), "err");


### PR DESCRIPTION
## Summary
- preserve whitespace-only WebSocket messages so intentional blank lines from the MUD server are rendered
- only inject separators between grouped lines when necessary to avoid collapsing server formatting
- mirror the overlay adjustments in the published JavaScript bundle

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d11a947b6483208141dd8282e3eb9c