### PR TITLE
Remove console-based debugging hooks from MUD overlay

### DIFF
--- a/layouts/partials/mud-overlay.html
+++ b/layouts/partials/mud-overlay.html
@@ -78,7 +78,14 @@
         window.spawnMudOverlay(target || undefined, opts);
       }
     };
-    s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
+    s.onerror = function(){
+      loading = false;
+      if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+        try {
+          window.dispatchEvent(new CustomEvent('mud-overlay-load-error', { detail: { src: src } }));
+        } catch (err) {}
+      }
+    };
     document.head.appendChild(s);
   }
 

--- a/public/js/mud-overlay.js
+++ b/public/js/mud-overlay.js
@@ -618,7 +618,6 @@
             return;
           }
           if (!s) return;
-          console.log("[MUD WS] raw message:", JSON.stringify(s));
           append(s, "outl");
         } catch (e) {
           append("Message handling error: " + (e?.message || e), "err");
@@ -627,8 +626,7 @@
       ws.addEventListener("error", (e) => {
         flushGroup();
         setStatus("error", "error");
-        append("WebSocket error (see console).", "err");
-        console.error("[MUD WS] error", e);
+        append("WebSocket error.", "err");
       });
       ws.addEventListener("close", (e) => {
         flushGroup();

--- a/public/posts/learning-go-building-a-mud/index.html
+++ b/public/posts/learning-go-building-a-mud/index.html
@@ -292,7 +292,14 @@ Aug 10, 2025
         window.spawnMudOverlay(target || undefined, opts);
       }
     };
-    s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
+    s.onerror = function(){
+      loading = false;
+      if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+        try {
+          window.dispatchEvent(new CustomEvent('mud-overlay-load-error', { detail: { src: src } }));
+        } catch (err) {}
+      }
+    };
     document.head.appendChild(s);
   }
 

--- a/public/projects/dmud/index.html
+++ b/public/projects/dmud/index.html
@@ -281,7 +281,14 @@
         window.spawnMudOverlay(target || undefined, opts);
       }
     };
-    s.onerror = function(){ loading = false; console.error('Failed to load MUD overlay script at', src); };
+    s.onerror = function(){
+      loading = false;
+      if (typeof window !== 'undefined' && typeof window.dispatchEvent === 'function') {
+        try {
+          window.dispatchEvent(new CustomEvent('mud-overlay-load-error', { detail: { src: src } }));
+        } catch (err) {}
+      }
+    };
     document.head.appendChild(s);
   }
 

--- a/static/js/mud-overlay.js
+++ b/static/js/mud-overlay.js
@@ -618,7 +618,6 @@
             return;
           }
           if (!s) return;
-          console.log("[MUD WS] raw message:", JSON.stringify(s));
           append(s, "outl");
         } catch (e) {
           append("Message handling error: " + (e?.message || e), "err");
@@ -627,8 +626,7 @@
       ws.addEventListener("error", (e) => {
         flushGroup();
         setStatus("error", "error");
-        append("WebSocket error (see console).", "err");
-        console.error("[MUD WS] error", e);
+        append("WebSocket error.", "err");
       });
       ws.addEventListener("close", (e) => {
         flushGroup();


### PR DESCRIPTION
## Summary
- remove remaining console logging from the MUD overlay loader and websocket handler
- dispatch a custom error event when the overlay script fails to load so downstream code can react without relying on the console
- regenerate built assets to incorporate the updated scripts

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68d25af8e318832087092bd4c7902a79