### PR TITLE
Add spacing between blogroll button gifs

### DIFF
--- a/themes/hugo-theme-console/layouts/index.html
+++ b/themes/hugo-theme-console/layouts/index.html
@@ -31,7 +31,7 @@
 <h1>Blogrolls & Webrings</h1>
 <p><a href="https://chadxz.dev/" target="_blank">chad</a> - <a href="https://blog.rldn.net/" target="_blank">mog</a> - <a href="https://frcv.net" target="_blank">nathan</a> - <a href="https://steveklabnik.com/writing/" target="_blank">steve klabnik</a></p>
 <p>
-  <a href="{{ "/" | relURL }}" style="display:inline-block;">
+  <a href="{{ "/" | relURL }}" style="display:inline-block; margin-right: 8px;">
     <img
       src="{{ "dustybutton.gif" | relURL }}"
       alt="dusty"


### PR DESCRIPTION
## Summary
- add inline margin to the home page blogroll button linking back to Dusty to create spacing before the Hunter badge

## Testing
- manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7b717539c8320a2eab5b189c8d4e9