### PR TITLE
Fix highlight shortcode rendering extra space after links

### DIFF
--- a/layouts/shortcodes/h1.html
+++ b/layouts/shortcodes/h1.html
@@ -1,1 +1,3 @@
-<mark class="hl">{{- trim .Inner " \n\r\t" -}}</mark>
+{{- $inner := trim .Inner " \n\r\t" -}}
+{{- $rendered := .Page.RenderString (dict "display" "inline") $inner -}}
+<mark class="hl">{{- trim $rendered " \n\r\t" | safeHTML -}}</mark>

--- a/public/about/index.html
+++ b/public/about/index.html
@@ -55,7 +55,9 @@
 <meta name="twitter:title" content="Dustin Clark"/>
 <meta name="twitter:description" content=" Yoooo, I&rsquo;m Dusty✌️
 I love taking pictures traveling shit-posting and making things
-In gradschool working thru my master&rsquo;s degree in Computer Science and Founding Engineer at Nexus If you&rsquo;d like to get in touch for any reason just reach out to one of my socials I&rsquo;d love to chat!
+In gradschool working thru my master&rsquo;s degree in Computer Science and Founding Engineer at Nexus
+If you&rsquo;d like to get in touch for any reason just reach out to one of my socials
+I&rsquo;d love to chat!
 This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities Vibe "/>
 
 </head>
@@ -198,16 +200,16 @@ This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities 
     </div>
     <div class="container animate-fade-up">
 <h1>Dustin Clark</h1>
-<div id="pr-1759308031317124562" class="profile-row" style="--img-size: 250px">
+<div id="pr-1759308288119632755" class="profile-row" style="--img-size: 250px">
   <style>
      
-    #pr-1759308031317124562.profile-row {
+    #pr-1759308288119632755.profile-row {
       display: flex;
       align-items: flex-start;
       gap: 1rem;
       margin: 1rem 0;
     }
-    #pr-1759308031317124562 .profile-row__img {
+    #pr-1759308288119632755 .profile-row__img {
       flex: 0 0 var(--img-size);
       width: var(--img-size);
       height: var(--img-size);
@@ -215,19 +217,19 @@ This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities 
       border-radius: 50%;
       display: block;
     }
-    #pr-1759308031317124562 .profile-row__text {
+    #pr-1759308288119632755 .profile-row__text {
       flex: 1 1 0;
       min-width: 12rem;
 
     }
      
-    #pr-1759308031317124562 .profile-row__text p {
+    #pr-1759308288119632755 .profile-row__text p {
       margin: 0 0 0.75rem 0;
       text-align: left;
     }
     @media (max-width: 600px) {
-      #pr-1759308031317124562.profile-row { flex-direction: column; align-items: center; }
-      #pr-1759308031317124562 .profile-row__text { width: 100%; }
+      #pr-1759308288119632755.profile-row { flex-direction: column; align-items: center; }
+      #pr-1759308288119632755 .profile-row__text { width: 100%; }
     }
   </style>
 
@@ -241,14 +243,14 @@ This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities 
     decoding="async"
   />
   <div class="profile-row__text"><p>Yoooo, I&rsquo;m Dusty✌️</p>
-<p>I love taking <mark class="hl"><a href="https://instagram.com/dustywusty" target="_blank" rel="noopener">pictures</a> </mark>
-<mark class="hl"><a href="https://instagram.com/dustywusty" target="_blank" rel="noopener">traveling</a> </mark>
+<p>I love taking <mark class="hl"><a href="https://instagram.com/dustywusty" target="_blank" rel="noopener">pictures</a></mark>
+<mark class="hl"><a href="https://instagram.com/dustywusty" target="_blank" rel="noopener">traveling</a></mark>
 <mark class="hl">shit-posting</mark>
-and <mark class="hl"><a href="https://github.com/dustywusty" target="_blank" rel="noopener">making</a> </mark>
+and <mark class="hl"><a href="https://github.com/dustywusty" target="_blank" rel="noopener">making</a></mark>
 things</p>
 <p>In gradschool working thru my master&rsquo;s degree in Computer Science and <mark class="hl">Founding Engineer</mark>
-at <mark class="hl"><a href="https://nexus.gg" target="_blank" rel="noopener">Nexus</a> </mark></p>
-<p>If you&rsquo;d like to get in touch for any reason just reach out to one of my <mark class="hl"><a href="https://dusty.wtf" target="_blank" rel="noopener">socials</a> </mark></p>
+at <mark class="hl"><a href="https://nexus.gg" target="_blank" rel="noopener">Nexus</a></mark></p>
+<p>If you&rsquo;d like to get in touch for any reason just reach out to one of my <mark class="hl"><a href="https://dusty.wtf" target="_blank" rel="noopener">socials</a></mark></p>
 <p>I&rsquo;d love to chat!</p>
 </div>
 </div>

--- a/public/index.xml
+++ b/public/index.xml
@@ -34,7 +34,7 @@
       <link>http://localhost:1313/about/</link>
       <pubDate>Sat, 05 Nov 2016 21:05:33 +0530</pubDate>
       <guid>http://localhost:1313/about/</guid>
-      <description> Yoooo, I&amp;rsquo;m Dusty✌️&#xA;I love taking pictures traveling shit-posting and making things&#xA;In gradschool working thru my master&amp;rsquo;s degree in Computer Science and Founding Engineer at Nexus If you&amp;rsquo;d like to get in touch for any reason just reach out to one of my socials I&amp;rsquo;d love to chat!&#xA;This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities Vibe </description>
+      <description> Yoooo, I&amp;rsquo;m Dusty✌️&#xA;I love taking pictures traveling shit-posting and making things&#xA;In gradschool working thru my master&amp;rsquo;s degree in Computer Science and Founding Engineer at Nexus&#xA;If you&amp;rsquo;d like to get in touch for any reason just reach out to one of my socials&#xA;I&amp;rsquo;d love to chat!&#xA;This Site hugo-theme-console/ hugo github pages fontawesome dusty.wtf Geocities Vibe </description>
     </item>
   </channel>
 </rss>


### PR DESCRIPTION
## Summary
- render the highlight shortcode content with inline Markdown so links no longer leave trailing whitespace inside the mark element
- regenerate the about page and RSS feed to capture the updated highlight markup

## Testing
- hugo

------
https://chatgpt.com/codex/tasks/task_e_68dce94b6e9c8320b01d59c3f73286f7